### PR TITLE
Correct CMAKE_CXX_FLAGS for ninja, use unicode windows APIs explicitly

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,8 +29,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
 
 elseif (WIN32)
 
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}
-      /wd4244 /wd4305 /wd4996 /wd4267 /wd4018")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4305 /wd4996 /wd4267 /wd4018")
 
 endif()
 

--- a/lib/host/windows/base_view.cpp
+++ b/lib/host/windows/base_view.cpp
@@ -87,7 +87,7 @@ namespace cycfi { namespace elements
 
       view_info* get_view_info(HWND hwnd)
       {
-         auto param = GetWindowLongPtr(hwnd, GWLP_USERDATA);
+         auto param = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
          return reinterpret_cast<view_info*>(param);
       }
 
@@ -367,7 +367,7 @@ namespace cycfi { namespace elements
 
       LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam)
       {
-         auto param = GetWindowLongPtr(hwnd, GWLP_USERDATA);
+         auto param = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
          auto* info = get_view_info(hwnd);
          switch (message)
          {
@@ -463,7 +463,7 @@ namespace cycfi { namespace elements
                break;
 
             default:
-               return DefWindowProc(hwnd, message, wparam, lparam);
+               return DefWindowProcW(hwnd, message, wparam, lparam);
          }
          return 0;
       }
@@ -472,15 +472,15 @@ namespace cycfi { namespace elements
       {
          init_view_class()
          {
-            WNDCLASS windowClass = {0};
+            WNDCLASSW windowClass = {0};
             windowClass.hbrBackground = nullptr;
             windowClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
             windowClass.hInstance = nullptr;
             windowClass.lpfnWndProc = WndProc;
             windowClass.lpszClassName = L"ElementsView";
             windowClass.style = CS_HREDRAW | CS_VREDRAW;
-            if (!RegisterClass(&windowClass))
-               MessageBox(nullptr, L"Could not register class", L"Error", MB_OK);
+            if (!RegisterClassW(&windowClass))
+               MessageBoxW(nullptr, L"Could not register class", L"Error", MB_OK);
 
             auto pwd = fs::current_path();
             auto resource_path = pwd / "resources";
@@ -495,7 +495,7 @@ namespace cycfi { namespace elements
    {
       static init_view_class init;
 
-      _view = CreateWindow(
+      _view = CreateWindowW(
          L"ElementsView",
          nullptr,
          WS_CHILD | WS_VISIBLE,
@@ -514,7 +514,7 @@ namespace cycfi { namespace elements
       );
 
       view_info* info = new view_info{ this };
-      SetWindowLongPtr(_view, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(info));
+      SetWindowLongPtrW(_view, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(info));
 
       // Create 16ms (60Hz) timer
       SetTimer(_view, IDT_TIMER1, 16, (TIMERPROC) nullptr);

--- a/lib/host/windows/window.cpp
+++ b/lib/host/windows/window.cpp
@@ -28,7 +28,7 @@ namespace cycfi { namespace elements
 
       window_info* get_window_info(HWND hwnd)
       {
-         auto param = GetWindowLongPtr(hwnd, GWLP_USERDATA);
+         auto param = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
          return reinterpret_cast<window_info*>(param);
       }
 
@@ -40,20 +40,20 @@ namespace cycfi { namespace elements
 
       void disable_minimize(HWND hwnd)
       {
-         SetWindowLong(hwnd, GWL_STYLE,
-            GetWindowLong(hwnd, GWL_STYLE) & ~WS_MINIMIZEBOX);
+         SetWindowLongW(hwnd, GWL_STYLE,
+            GetWindowLongW(hwnd, GWL_STYLE) & ~WS_MINIMIZEBOX);
       }
 
       void disable_maximize(HWND hwnd)
       {
-         SetWindowLong(hwnd, GWL_STYLE,
-            GetWindowLong(hwnd, GWL_STYLE) & ~WS_MAXIMIZEBOX);
+         SetWindowLongW(hwnd, GWL_STYLE,
+            GetWindowLongW(hwnd, GWL_STYLE) & ~WS_MAXIMIZEBOX);
       }
 
       void disable_resize(HWND hwnd)
       {
-         SetWindowLong(hwnd, GWL_STYLE,
-            GetWindowLong(hwnd, GWL_STYLE) & ~WS_SIZEBOX);
+         SetWindowLongW(hwnd, GWL_STYLE,
+            GetWindowLongW(hwnd, GWL_STYLE) & ~WS_SIZEBOX);
          disable_maximize(hwnd);
       }
 
@@ -134,7 +134,7 @@ namespace cycfi { namespace elements
                break;
 
             default:
-               return DefWindowProc(hwnd, message, wparam, lparam);
+               return DefWindowProcW(hwnd, message, wparam, lparam);
          }
          return 0;
       }
@@ -143,15 +143,15 @@ namespace cycfi { namespace elements
       {
          init_window_class()
          {
-            WNDCLASS windowClass = {0};
+            WNDCLASSW windowClass = {0};
             windowClass.hbrBackground = NULL;
             windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
             windowClass.hInstance = NULL;
             windowClass.lpfnWndProc = handle_event;
             windowClass.lpszClassName = L"ElementsWindow";
             windowClass.style = CS_HREDRAW | CS_VREDRAW;
-            if (!RegisterClass(&windowClass))
-               MessageBox(nullptr, L"Could not register class", L"Error", MB_OK);
+            if (!RegisterClassW(&windowClass))
+               MessageBoxW(nullptr, L"Could not register class", L"Error", MB_OK);
          }
       };
    }
@@ -163,7 +163,7 @@ namespace cycfi { namespace elements
       std::wstring wname = utf8_decode(name);
       auto scale = GetDpiForSystem() / 96.0;
 
-      _window = CreateWindow(
+      _window = CreateWindowW(
          L"ElementsWindow",
          wname.c_str(),
          WS_OVERLAPPEDWINDOW,
@@ -174,7 +174,7 @@ namespace cycfi { namespace elements
       );
 
       window_info* info = new window_info{ this };
-      SetWindowLongPtr(_window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(info));
+      SetWindowLongPtrW(_window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(info));
 
       if (!(style_ & closable))
          disable_close(_window);


### PR DESCRIPTION
This solves two problems when using Visual Studio's CMake and Ninja:

* `ninja` complains about new line in `CMAKE_CXX_FLAGS`

* `UNICODE` is not defined, which makes (e. g.) `CreateWindow` an alias for `CreateWindowA` instead of `CreateWindowW` - fixed by using `*W` variants where necessary