### PR TITLE
make examples build condition a CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ add_subdirectory(${CYCFI_JSON_ROOT} "${CMAKE_CURRENT_BINARY_DIR}/json")
 
 add_subdirectory(lib)
 
-if (NOT ELEMENTS_NO_EXAMPLES)
+option(ELEMENTS_BUILD_EXAMPLES "build Elements library examples" ON)
+
+if (ELEMENTS_BUILD_EXAMPLES)
    add_subdirectory(examples)
 endif()
 


### PR DESCRIPTION
This will make the option visible both in the CMake GUI and in -L
command line option.

This closes #10 