### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,23 @@
 #
 #  Distributed under the MIT License (https://opensource.org/licenses/MIT)
 ###############################################################################
-cmake_minimum_required(VERSION 3.7.2...3.15.0)
+cmake_minimum_required(VERSION 3.9.6...3.15.0)
+
+set(DEFAULT_BUILD_TYPE "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE
+        STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+include(CheckIPOSupported)
+check_ipo_supported(RESULT IPO_SUPPORTED)
+if(IPO_SUPPORTED)
+    message(STATUS "Link-time optimization supported. Will be enabled in Release build type")
+endif()
 
 if (NOT DEFINED CYCFI_JSON_ROOT)
   set(CYCFI_JSON_ROOT ../json)
@@ -18,4 +34,3 @@ option(ELEMENTS_BUILD_EXAMPLES "build Elements library examples" ON)
 if (ELEMENTS_BUILD_EXAMPLES)
    add_subdirectory(examples)
 endif()
-

--- a/CMakeMain.txt
+++ b/CMakeMain.txt
@@ -105,7 +105,7 @@ elseif (WIN32)
          VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       )
    endif()
-   
+
    configure_file(
       ${CMAKE_CURRENT_LIST_DIR}/resources/config.json.in
       "${CMAKE_CURRENT_BINARY_DIR}/config.json"
@@ -159,5 +159,6 @@ if (APPLE)
    )
 endif()
 
-
-
+if(IPO_SUPPORTED AND CMAKE_BUILD_TYPE STREQUAL "Release")
+   set_target_properties(${ELEMENTS_APP_PROJECT} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()


### PR DESCRIPTION
- if no CMAKE_BUILD_TYPE is specified, it will now default to Release
- if if CMAKE_BUILD_TYPE is Release and LTO is supported, it will be
added to elements library and examples targets
- removed trailing whitesapce