### PR TITLE
removed unwanted shared_ptr copy

### DIFF
--- a/lib/include/elements/element/element.hpp
+++ b/lib/include/elements/element/element.hpp
@@ -92,7 +92,7 @@ namespace cycfi { namespace elements
    }
 
    template <typename Element>
-   inline auto get(std::shared_ptr<Element> ptr)
+   inline auto get(std::shared_ptr<Element> const& ptr)
    {
       return std::weak_ptr<Element>(ptr);
    }


### PR DESCRIPTION
weak_ptr ctor takes shared_ptr by const reference