### PR TITLE
add using base_type::value; where missing

### DIFF
--- a/lib/include/elements/element/dial.hpp
+++ b/lib/include/elements/element/dial.hpp
@@ -64,6 +64,7 @@ namespace cycfi { namespace elements
    public:
 
       static std::size_t const size = _size;
+      using element::value;
 
                               basic_knob_element(color c = colors::black)
                                : _color(c), _value(0)

--- a/lib/include/elements/element/image.hpp
+++ b/lib/include/elements/element/image.hpp
@@ -102,6 +102,9 @@ namespace cycfi { namespace elements
    class sprite : public image
    {
    public:
+
+      using image::value;
+
                               sprite(char const* filename, float height, float scale = 1);
 
       view_limits             limits(basic_context const& ctx) const override;


### PR DESCRIPTION
Types which do not override all overloads shadow base type overloads.
This casues compilation errors when a widget is put into proxy or
indirect which try to forward all overloads.