### PR TITLE
Fix linking of freetype and threads on linux

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -197,9 +197,9 @@ if (MSVC)
    else()
 	  target_link_libraries(elements PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/external/freetype/win32/freetype.lib)
    endif()
-elseif (LINUX OR WIN32)
-   pkg_check_modules(freetype REQUIRED IMPORTED_TARGET freetype)
-   target_link_libraries(elements PUBLIC PkgConfig::freetype)
+elseif (UNIX OR WIN32)
+   pkg_check_modules(freetype2 REQUIRED IMPORTED_TARGET freetype2)
+   target_link_libraries(elements PUBLIC PkgConfig::freetype2)
 endif()
 
 ###############################################################################
@@ -243,7 +243,7 @@ target_link_libraries(elements PUBLIC
    json
 )
 
-if (LINUX OR (WIN32 AND NOT MSVC))
+if (UNIX OR (WIN32 AND NOT MSVC))
    find_package(Threads)
    target_link_libraries(elements PUBLIC Threads::Threads)
 endif()


### PR DESCRIPTION
There were two issues:

- Checking for LINUX instead of UNIX platform
- pkg-config for freetype did not work

For the second I have changed the code to use find_package instead. To
be able to use proper CMake targets for this I had to bump the required
version number. Please let me know if this is not acceptable.