### PR TITLE
Replace boost::filesystem with std::filesystem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,128 @@
+name: Build
+on: [push, pull_request]
+env:
+  BUILD_TYPE: Release
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - name: "Windows Latest MSVC"
+          os: windows-latest
+          cc: "cl"
+          cxx: "cl"
+          environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        - name: "Ubuntu Latest GCC"
+          os: ubuntu-latest
+          cc: "gcc"
+          cxx: "g++"
+          # If this env variable is present, we set BOOST_ROOT to its content
+          # Github workers put newer Boost versions there
+          boost_root: "BOOST_ROOT_1_72_0"
+        - name: "macOS Latest Clang"
+          os: macos-latest
+          cc: "clang"
+          cxx: "clang++"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: elements
+    - name: Checkout infra repo
+      uses: actions/checkout@v2
+      with:
+        repository: cycfi/infra
+        path: infra
+    - name: Checkout json repo
+      uses: actions/checkout@v2
+      with:
+        repository: cycfi/json
+        path: json
+    - name: Install package dependencies
+      id: cmake_and_ninja
+      shell: cmake -P {0}
+      run: |
+        if ("${{ runner.os }}" STREQUAL "Windows")
+          execute_process(COMMAND choco install ninja)
+        elseif ("${{ runner.os }}" STREQUAL "Linux")
+          execute_process(COMMAND sudo apt-get install libcairo2-dev)
+          execute_process(COMMAND sudo apt-get install libgtk-3-dev)
+          execute_process(COMMAND sudo apt-get install ninja-build)
+        elseif ("${{ runner.os }}" STREQUAL "macOS")
+          execute_process(COMMAND brew install pkg-config)
+          execute_process(COMMAND brew install boost)
+          execute_process(COMMAND brew install cairo)
+          execute_process(COMMAND brew install fontconfig)
+          execute_process(COMMAND brew install ninja)
+        endif()
+    - name: Configure
+      shell: cmake -P {0}
+      working-directory: ./elements
+      run: |
+        set(ENV{CC} ${{ matrix.config.cc }})
+        set(ENV{CXX} ${{ matrix.config.cxx }})
+        # If the environment has boost_root defined, set BOOST_ROOT to it
+        if ( NOT "x${{ matrix.config.boost_root }}" STREQUAL "x")
+          set(ENV{BOOST_ROOT} $ENV{${{ matrix.config.boost_root }}})
+        endif()
+
+        # If we are on windows, run the environment script, parse it with cmake
+        # and set environment variables with it (required for Visual Studio)
+        if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+          execute_process(
+            COMMAND "${{ matrix.config.environment_script }}" && set
+            OUTPUT_FILE environment_script_output.txt
+          )
+          file(STRINGS environment_script_output.txt output_lines)
+          foreach(line IN LISTS output_lines)
+            if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
+              set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
+            endif()
+          endforeach()
+        endif()
+
+        execute_process(
+          COMMAND ${CMAKE_COMMAND}
+            -S .
+            -B build
+            -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
+            -G Ninja
+            -D CMAKE_MAKE_PROGRAM=ninja
+          RESULT_VARIABLE result
+          ERROR_VARIABLE error_message
+        )
+
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Could not run with ${CMAKE_COMMAND}: Got ${error_message} - ${result}")
+        endif()
+    - name: Build
+      shell: cmake -P {0}
+      working-directory: ./elements
+      run: |
+        # If we are on windows, run the environment script, parse it with cmake
+        # and set environment variables with it (required for Visual Studio)
+        if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+          execute_process(
+            COMMAND "${{ matrix.config.environment_script }}" && set
+            OUTPUT_FILE environment_script_output.txt
+          )
+          file(STRINGS environment_script_output.txt output_lines)
+          foreach(line IN LISTS output_lines)
+            if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
+              set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
+            endif()
+          endforeach()
+        endif()
+
+        execute_process(
+          COMMAND ${CMAKE_COMMAND} --build build
+          RESULT_VARIABLE result
+          ERROR_VARIABLE error_message
+        )
+
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Could not run with ${CMAKE_COMMAND}: Got ${error_message} - ${result}")
+        endif()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ![Elements-Logo](docs/assets/images/elements.png) Elements C++ GUI library
 
+[![CMake Build Matrix](https://github.com/cycfi/elements/workflows/Build/badge.svg)](https://github.com/cycfi/elements/actions?query=workflow%3ABuild)
+
 ![alt Photon Sampler](docs/assets/images/photon_sampler.jpg)
 
 ## Introduction

--- a/examples/typography/CMakeLists.txt
+++ b/examples/typography/CMakeLists.txt
@@ -10,7 +10,6 @@ set(ELEMENTS_APP_ID "com.cycfi.typography")
 set(ELEMENTS_APP_VERSION "1.0")
 
 set(ELEMENTS_APP_RESOURCES
-   ${CMAKE_CURRENT_SOURCE_DIR}/resources/OpenSansCondensed-Light.ttf
    ${CMAKE_CURRENT_SOURCE_DIR}/resources/OpenSansCondensed-LightItalic.ttf
 )
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -234,13 +234,8 @@ if (UNIX AND NOT APPLE)
 endif()
 
 ###############################################################################
-# Boost
-
-set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.68 REQUIRED COMPONENTS filesystem system date_time regex)
-
-target_link_libraries(elements PUBLIC Boost::boost Boost::filesystem Boost::system Boost::date_time Boost::regex)
-target_compile_definitions(elements PRIVATE BOOST_ALL_NO_LIB)
+# Boost headers
+find_package(Boost 1.68 REQUIRED)
 
 ###############################################################################
 # Global options

--- a/lib/host/linux/app.cpp
+++ b/lib/host/linux/app.cpp
@@ -13,8 +13,6 @@
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
-
    struct config
    {
       std::string application_title;
@@ -36,11 +34,11 @@ namespace cycfi { namespace elements
 {
    config get_config()
    {
-      fs::path path = "config.json";
-      CYCFI_ASSERT(fs::exists(path), "Error: config.json not exist.");
+      std::filesystem::path path = "config.json";
+      CYCFI_ASSERT(std::filesystem::exists(path), "Error: config.json not exist.");
       auto r = json::load<config>(path);
       CYCFI_ASSERT(r, "Error: Invalid config.json.");
-      return r.get();
+      return *r;
    }
 
    // Some app globals

--- a/lib/host/linux/base_view.cpp
+++ b/lib/host/linux/base_view.cpp
@@ -425,7 +425,7 @@ namespace cycfi { namespace elements
    {
       init_view_class()
       {
-         auto pwd = fs::current_path();
+         auto pwd = std::filesystem::current_path();
          auto resource_path = pwd / "resources";
          resource_paths.push_back(resource_path);
       }

--- a/lib/host/macos/base_view.mm
+++ b/lib/host/macos/base_view.mm
@@ -41,9 +41,7 @@ namespace
       return 0;
    }
 
-   namespace fs = boost::filesystem;
-
-   void activate_font(fs::path font_path)
+   void activate_font(std::filesystem::path font_path)
    {
       NSArray* available_fonts = [[NSFontManager sharedFontManager] availableFonts];
       if (![available_fonts containsObject : [NSString stringWithUTF8String : font_path.stem().c_str()]])
@@ -77,7 +75,7 @@ namespace
          // Load the user fonts from the Resource folder. Normally this is automatically
          // done on application startup, but for plugins, we need to explicitly load
          // the user fonts ourself.
-         for (fs::directory_iterator it{ resource_path }; it != fs::directory_iterator{}; ++it)
+         for (std::filesystem::directory_iterator it{ resource_path }; it != std::filesystem::directory_iterator{}; ++it)
             if (it->path().extension() == ".ttf")
                activate_font(it->path());
       }
@@ -92,11 +90,11 @@ namespace cycfi { namespace elements
    NSUInteger  translate_key_to_modifier_flag(key_code key);
 
    // This is declared in font.hpp
-   fs::path get_user_fonts_directory()
+   std::filesystem::path get_user_fonts_directory()
    {
       char resource_path[PATH_MAX];
       get_resource_path(resource_path);
-      return fs::path(resource_path);
+      return std::filesystem::path(resource_path);
    }
 }}
 

--- a/lib/host/windows/app.cpp
+++ b/lib/host/windows/app.cpp
@@ -7,7 +7,6 @@
 #include <json/json.hpp>
 #include <json/json_io.hpp>
 #include <infra/assert.hpp>
-#include <boost/filesystem.hpp>
 #include <windows.h>
 #include <ShellScalingAPI.h>
 #include <shlobj.h>
@@ -15,8 +14,6 @@
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
-
    struct config
    {
       std::string application_title;
@@ -47,14 +44,14 @@ namespace cycfi { namespace elements
 {
    config get_config()
    {
-      fs::path path = "config.json";
+      std::filesystem::path path = "config.json";
 
-	   std::string fp = fs::absolute(path).string();
+      std::string fp = std::filesystem::absolute(path).string();
 
-      CYCFI_ASSERT(fs::exists(path), "Error: config.json not exist.");
+      CYCFI_ASSERT(std::filesystem::exists(path), "Error: config.json not exist.");
       auto r = json::load<config>(path);
       CYCFI_ASSERT(r, "Error: Invalid config.json.");
-      return r.get();
+      return *r;
    }
 
    config app_config;

--- a/lib/include/elements/support/font.hpp
+++ b/lib/include/elements/support/font.hpp
@@ -7,7 +7,7 @@
 #define ELEMENTS_FONT_X_FEBRUARY_11_2020
 
 #include <string_view>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 extern "C"
 {
@@ -304,8 +304,7 @@ namespace cycfi { namespace elements
    }
 
 #ifdef __APPLE__
-   namespace fs = boost::filesystem;
-   fs::path get_user_fonts_directory();
+   std::filesystem::path get_user_fonts_directory();
 #endif
 }}
 

--- a/lib/include/elements/support/resource_paths.hpp
+++ b/lib/include/elements/support/resource_paths.hpp
@@ -9,26 +9,24 @@
 #include <set>
 #include <string_view>
 #include <vector>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
-
    // Resources (e.g. images) that are identified by file names can be
    // absolute or relative paths. For relative paths, the resource_paths
    // vector below are used to search for such files, in the order they
    // appear in the vector. Platform code provides the initial paths.
    // Applications may add additional paths as needed.
 
-   extern std::vector<fs::path> resource_paths;
+  extern std::vector<std::filesystem::path> resource_paths;
 
    // Search for a file using the resource_paths. Returns an empty
    // string if file is not found.
    std::string find_file(std::string_view file);
 
    // Get the application data path
-   fs::path app_data_path();
+   std::filesystem::path app_data_path();
 }}
 
 #endif

--- a/lib/src/support/font.cpp
+++ b/lib/src/support/font.cpp
@@ -37,7 +37,6 @@
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
    namespace
    {
       inline void ltrim(std::string& s)
@@ -153,11 +152,11 @@ namespace cycfi { namespace elements
 #ifdef __APPLE__
          auto resources_path = get_user_fonts_directory();
 #else
-         auto resources_path = (fs::current_path() / "resources").generic_string();
+         auto resources_path = (std::filesystem::current_path() / "resources").generic_string();
 #ifdef _WIN32
          TCHAR windir[MAX_PATH];
          GetWindowsDirectory(windir, MAX_PATH);
-         auto fonts_path = (fs::path(windir) / "fonts").generic_string();
+         auto fonts_path = (std::filesystem::path(windir) / "fonts").generic_string();
          FcConfigAppFontAddDir(config, (FcChar8 const*)fonts_path.c_str());
 #endif
 #endif

--- a/lib/src/support/resource_paths.cpp
+++ b/lib/src/support/resource_paths.cpp
@@ -4,28 +4,27 @@
    Distributed under the MIT License [ https://opensource.org/licenses/MIT ]
 =============================================================================*/
 #include <elements/support/resource_paths.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <string>
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
-   std::vector<fs::path> resource_paths;
+   std::vector<std::filesystem::path> resource_paths;
 
    std::string find_file(std::string_view file)
    {
       std::string full_path;
-      if (fs::path(file.data()).is_absolute())
+      if (std::filesystem::path(file.data()).is_absolute())
       {
-         if (fs::exists(full_path))
+         if (std::filesystem::exists(full_path))
             full_path = file;
       }
       else
       {
          for (auto const& path : resource_paths)
          {
-            fs::path target = fs::path(path) / file.data();
-            if (fs::exists(target))
+            std::filesystem::path target = std::filesystem::path(path) / file.data();
+            if (std::filesystem::exists(target))
             {
                full_path = target.string();
                break;


### PR DESCRIPTION
(Associated PR https://github.com/cycfi/json/pull/2 )

This PR replaces the dependency on _boost::filesystem_ with _std::filesystem_, allowing to rely only on the header parts of boost.
