### PR TITLE
Use std::filesystem or ghc::filesystem instead of boost:filesystem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/external/filesystem"]
+	path = lib/external/filesystem
+	url = https://github.com/gulrak/filesystem.git

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -154,7 +154,10 @@ target_sources(elements
    PUBLIC ${ELEMENTS_HEADERS}
 )
 
-target_include_directories(elements PUBLIC include)
+target_include_directories(elements PUBLIC
+  include
+  external/filesystem/include
+)
 
 target_compile_features(elements PUBLIC cxx_std_17)
 
@@ -234,13 +237,8 @@ if (UNIX AND NOT APPLE)
 endif()
 
 ###############################################################################
-# Boost
-
-set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.68 REQUIRED COMPONENTS filesystem system date_time regex)
-
-target_link_libraries(elements PUBLIC Boost::boost Boost::filesystem Boost::system Boost::date_time Boost::regex)
-target_compile_definitions(elements PRIVATE BOOST_ALL_NO_LIB)
+# Boost headers
+find_package(Boost 1.68 REQUIRED)
 
 ###############################################################################
 # Global options

--- a/lib/host/linux/app.cpp
+++ b/lib/host/linux/app.cpp
@@ -4,6 +4,7 @@
    Distributed under the MIT License [ https://opensource.org/licenses/MIT ]
 =============================================================================*/
 #include <elements/app.hpp>
+#include <elements/detail/filesystem.hpp>
 #include <infra/assert.hpp>
 #include <json/json_io.hpp>
 #include <string>
@@ -13,8 +14,6 @@
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
-
    struct config
    {
       std::string application_title;
@@ -40,7 +39,7 @@ namespace cycfi { namespace elements
       CYCFI_ASSERT(fs::exists(path), "Error: config.json not exist.");
       auto r = json::load<config>(path);
       CYCFI_ASSERT(r, "Error: Invalid config.json.");
-      return r.get();
+      return *r;
    }
 
    // Some app globals

--- a/lib/host/linux/base_view.cpp
+++ b/lib/host/linux/base_view.cpp
@@ -13,6 +13,7 @@
 #include <elements/support/text_utils.hpp>
 #include <json/json_io.hpp>
 #include <gtk/gtk.h>
+#include <map>
 #include <string>
 
 namespace cycfi { namespace elements

--- a/lib/host/windows/app.cpp
+++ b/lib/host/windows/app.cpp
@@ -7,7 +7,7 @@
 #include <json/json.hpp>
 #include <json/json_io.hpp>
 #include <infra/assert.hpp>
-#include <boost/filesystem.hpp>
+#include <elements/detail/filesystem.hpp>
 #include <windows.h>
 #include <ShellScalingAPI.h>
 #include <shlobj.h>

--- a/lib/include/elements/detail/filesystem.hpp
+++ b/lib/include/elements/detail/filesystem.hpp
@@ -1,0 +1,31 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+
+   Distributed under the MIT License [ https://opensource.org/licenses/MIT ]
+=============================================================================*/
+#if !defined(ELEMENTS_DETAIL_FILESYSTEM_APRIL_1_2020)
+#define ELEMENTS_DETAIL_FILESYSTEM_APRIL_1_2020
+
+#if defined(__apple_build_version__) && (__apple_build_version__ <= 11000033L)
+# define ELEMENTS_HAS_NO_STD_FS
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
+# define ELEMENTS_USE_STD_FS
+#endif
+
+#if defined(__cplusplus) && __cplusplus >= 201703L && defined(__has_include)
+# if __has_include(<filesystem>) && !defined(ELEMENTS_HAS_NO_STD_FS)
+#  define ELEMENTS_USE_STD_FS
+# endif
+#endif
+
+#if defined(ELEMENTS_USE_STD_FS)
+# include <filesystem>
+  namespace fs = std::filesystem;
+#else
+# include <ghc/filesystem.hpp>
+  namespace fs = ghc::filesystem;
+#endif
+
+#endif

--- a/lib/include/elements/support/canvas.hpp
+++ b/lib/include/elements/support/canvas.hpp
@@ -11,7 +11,7 @@
 #include <elements/support/circle.hpp>
 #include <elements/support/pixmap.hpp>
 #include <elements/support/font.hpp>
-#include <boost/filesystem.hpp>
+#include <elements/detail/filesystem.hpp>
 
 #include <vector>
 #include <functional>

--- a/lib/include/elements/support/font.hpp
+++ b/lib/include/elements/support/font.hpp
@@ -7,7 +7,7 @@
 #define ELEMENTS_FONT_X_FEBRUARY_11_2020
 
 #include <string_view>
-#include <boost/filesystem.hpp>
+#include <elements/detail/filesystem.hpp>
 
 extern "C"
 {
@@ -304,7 +304,6 @@ namespace cycfi { namespace elements
    }
 
 #ifdef __APPLE__
-   namespace fs = boost::filesystem;
    fs::path get_user_fonts_directory();
 #endif
 }}

--- a/lib/include/elements/support/resource_paths.hpp
+++ b/lib/include/elements/support/resource_paths.hpp
@@ -9,12 +9,10 @@
 #include <set>
 #include <string_view>
 #include <vector>
-#include <boost/filesystem.hpp>
+#include <elements/detail/filesystem.hpp>
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
-
    // Resources (e.g. images) that are identified by file names can be
    // absolute or relative paths. For relative paths, the resource_paths
    // vector below are used to search for such files, in the order they

--- a/lib/src/support/font.cpp
+++ b/lib/src/support/font.cpp
@@ -9,7 +9,7 @@
 #include <cairo.h>
 #include <cairo-ft.h>
 #include <fontconfig/fontconfig.h>
-#include <boost/filesystem.hpp>
+#include <elements/detail/filesystem.hpp>
 
 #ifndef __APPLE__
 # include <ft2build.h>
@@ -37,7 +37,6 @@
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
    namespace
    {
       inline void ltrim(std::string& s)

--- a/lib/src/support/resource_paths.cpp
+++ b/lib/src/support/resource_paths.cpp
@@ -4,12 +4,11 @@
    Distributed under the MIT License [ https://opensource.org/licenses/MIT ]
 =============================================================================*/
 #include <elements/support/resource_paths.hpp>
-#include <boost/filesystem.hpp>
+#include <elements/detail/filesystem.hpp>
 #include <string>
 
 namespace cycfi { namespace elements
 {
-   namespace fs = boost::filesystem;
    std::vector<fs::path> resource_paths;
 
    std::string find_file(std::string_view file)


### PR DESCRIPTION
Similar to what is being done in [artist](https://github.com/cycfi/artist/tree/windows_port/lib/include/artist)

Possibly obsoletes and supersedes https://github.com/cycfi/elements/pull/79 