### PR TITLE
Add the custom UI host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(cmake/CMakeInclude.txt)
 
 option(ELEMENTS_BUILD_EXAMPLES "build Elements library examples" ON)
 option(ELEMENTS_ENABLE_LTO "enable link time optimization for Elements targets" OFF)
-set(ELEMENTS_HOST_UI_LIBRARY "" CACHE STRING "gtk, cocoa or win32")
+set(ELEMENTS_HOST_UI_LIBRARY "" CACHE STRING "gtk, cocoa, win32 or custom")
 option(ELEMENTS_HOST_ONLY_WIN7 "If host UI library is win32, reduce elements features to support Windows 7" OFF)
 
 add_subdirectory(lib)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -109,7 +109,9 @@ set(ELEMENTS_HEADERS
    include/elements.hpp
 )
 
-if (APPLE)
+if (ELEMENTS_HOST_UI_LIBRARY STREQUAL "custom")
+   set(ELEMENTS_HOST)
+elseif (APPLE)
    set(ELEMENTS_HOST
       host/macos/app.mm
       host/macos/base_view.mm
@@ -275,6 +277,8 @@ elseif(ELEMENTS_HOST_UI_LIBRARY STREQUAL "win32")
         target_compile_definitions(elements PRIVATE ELEMENTS_HOST_ONLY_WIN7)
         message(STATUS "Windows 7 compatibility enabled")
     endif()
+elseif(ELEMENTS_HOST_UI_LIBRARY STREQUAL "custom")
+    target_compile_definitions(elements PUBLIC ELEMENTS_HOST_UI_LIBRARY_CUSTOM)
 else()
     message(FATAL_ERROR "Invalid ELEMENTS_HOST_UI_LIBRARY=${ELEMENTS_HOST_UI_LIBRARY}. Set gtk, cocoa or win32.")
 endif()

--- a/lib/include/elements/base_view.hpp
+++ b/lib/include/elements/base_view.hpp
@@ -285,6 +285,9 @@ namespace cycfi { namespace elements
 #elif defined(ELEMENTS_HOST_UI_LIBRARY_WIN32)
    using host_view_handle = HWND;
    using host_window_handle = HWND;
+#elif defined(ELEMENTS_HOST_UI_LIBRARY_CUSTOM)
+   using host_view_handle = void*;
+   using host_window_handle = void*;
 #else
    #error no ELEMENTS_HOST_UI_LIBRARY_* set
 #endif


### PR DESCRIPTION
HI, this permits to implements another custom UI host than the 3 choices offered.

This is in particular for Linux audio plugins, in which case Gtk cannot work.
Instead I implement a custom host over the window library [pugl](https://github.com/lv2/pugl).

However this needs some small changes in Elements, which are brought by this PR.

For reference my host is located here.
https://github.com/jpcima/sfizz/tree/editor%2Belements/editor/src/host
