### PR TITLE
proxy forwarding reimplementation

### DIFF
--- a/lib/include/elements/element/align.hpp
+++ b/lib/include/elements/element/align.hpp
@@ -8,6 +8,7 @@
 
 #include <elements/element/proxy.hpp>
 #include <elements/support/context.hpp>
+#include <infra/support.hpp>
 #include <memory>
 
 namespace cycfi { namespace elements
@@ -37,43 +38,43 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject, align_element_base>;
 
-                              halign_element(float align, Subject&& subject);
+                              halign_element(float align, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
    };
 
    template <typename Subject>
-   inline halign_element<Subject>
+   inline halign_element<remove_cvref_t<Subject>>
    halign(float align, Subject&& subject)
    {
       return { align, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline halign_element<Subject>
+   inline halign_element<remove_cvref_t<Subject>>
    align_left(Subject&& subject)
    {
       return { 0.0, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline halign_element<Subject>
+   inline halign_element<remove_cvref_t<Subject>>
    align_center(Subject&& subject)
    {
       return { 0.5, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline halign_element<Subject>
+   inline halign_element<remove_cvref_t<Subject>>
    align_right(Subject&& subject)
    {
       return { 1.0, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline halign_element<Subject>::halign_element(float align, Subject&& subject)
-    : base_type(std::forward<Subject>(subject), align)
+   inline halign_element<Subject>::halign_element(float align, Subject subject)
+    : base_type(std::move(subject), align)
    {}
 
    template <typename Subject>
@@ -105,43 +106,43 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject, align_element_base>;
 
-                              valign_element(float align, Subject&& subject);
+                              valign_element(float align, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
    };
 
    template <typename Subject>
-   inline valign_element<Subject>
+   inline valign_element<remove_cvref_t<Subject>>
    valign(float align, Subject&& subject)
    {
       return { align, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline valign_element<Subject>
+   inline valign_element<remove_cvref_t<Subject>>
    align_top(Subject&& subject)
    {
       return { 0.0, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline valign_element<Subject>
+   inline valign_element<remove_cvref_t<Subject>>
    align_middle(Subject&& subject)
    {
       return { 0.5, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline valign_element<Subject>
+   inline valign_element<remove_cvref_t<Subject>>
    align_bottom(Subject&& subject)
    {
       return { 1.0, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   valign_element<Subject>::valign_element(float align, Subject&& subject)
-    : base_type(std::forward<Subject>(subject), align)
+   valign_element<Subject>::valign_element(float align, Subject subject)
+    : base_type(std::move(subject), align)
    {}
 
    template <typename Subject>

--- a/lib/include/elements/element/dial.hpp
+++ b/lib/include/elements/element/dial.hpp
@@ -9,6 +9,7 @@
 #include <elements/element/proxy.hpp>
 #include <elements/element/tracker.hpp>
 #include <elements/support.hpp>
+#include <infra/support.hpp>
 #include <functional>
 
 namespace cycfi { namespace elements
@@ -43,7 +44,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline proxy<Subject, dial_base>
+   inline proxy<remove_cvref_t<Subject>, dial_base>
    dial(Subject&& subject, double init_value = 0.0)
    {
       return { std::forward<Subject>(subject), init_value };
@@ -134,8 +135,8 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              radial_element_base(Subject&& subject)
-                               : base_type(std::forward<Subject>(subject))
+                              radial_element_base(Subject subject)
+                               : base_type(std::move(subject))
                               {}
 
       view_limits             limits(basic_context const& ctx) const override;
@@ -199,7 +200,7 @@ namespace cycfi { namespace elements
    }
 
    template <std::size_t size, typename Subject>
-   inline radial_marks_element<size, Subject>
+   inline radial_marks_element<size, remove_cvref_t<Subject>>
    radial_marks(Subject&& subject)
    {
       return {std::forward<Subject>(subject)};
@@ -217,7 +218,7 @@ namespace cycfi { namespace elements
       using base_type = radial_element_base<_size, Subject>;
       using string_array = std::array<std::string, num_labels>;
 
-                              radial_labels_element(Subject&& subject, float font_size)
+                              radial_labels_element(Subject subject, float font_size)
                                : base_type(std::move(subject))
                                , _font_size(font_size)
                               {}
@@ -251,10 +252,10 @@ namespace cycfi { namespace elements
    }
 
    template <std::size_t size, typename Subject, typename... S>
-   inline radial_labels_element<size, Subject, sizeof...(S)>
+   inline radial_labels_element<size, remove_cvref_t<Subject>, sizeof...(S)>
    radial_labels(Subject&& subject, float font_size, S&&... s)
    {
-      auto r = radial_labels_element<size, Subject, sizeof...(S)>
+      auto r = radial_labels_element<size, remove_cvref_t<Subject>, sizeof...(S)>
          { std::move(subject), font_size };
       r._labels = {{ std::move(s)... }};
       return r;

--- a/lib/include/elements/element/floating.hpp
+++ b/lib/include/elements/element/floating.hpp
@@ -7,6 +7,7 @@
 #define ELEMENTS_FLOATING_JUNE_9_2016
 
 #include <elements/element/proxy.hpp>
+#include <infra/support.hpp>
 
 namespace cycfi { namespace elements
 {
@@ -32,7 +33,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline proxy<Subject, floating_element>
+   inline proxy<remove_cvref_t<Subject>, floating_element>
    floating(rect bounds, Subject&& subject)
    {
       return { std::forward<Subject>(subject), bounds };

--- a/lib/include/elements/element/gallery/button.hpp
+++ b/lib/include/elements/element/gallery/button.hpp
@@ -12,6 +12,7 @@
 #include <elements/element/margin.hpp>
 #include <elements/element/tile.hpp>
 #include <elements/support/theme.hpp>
+#include <infra/support.hpp>
 #include <string_view>
 #include <utility>
 
@@ -309,14 +310,14 @@ namespace cycfi { namespace elements
    // Basic buttons
    ////////////////////////////////////////////////////////////////////////////
    template <typename Subject>
-   inline basic_toggle_button<proxy<Subject, basic_button>>
+   inline basic_toggle_button<proxy<remove_cvref_t<Subject>, basic_button>>
    toggle_button(Subject&& subject)
    {
       return { std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline proxy<Subject, basic_button>
+   inline proxy<remove_cvref_t<Subject>, basic_button>
    momentary_button(Subject&& subject)
    {
       return { std::forward<Subject>(subject) };

--- a/lib/include/elements/element/indirect.hpp
+++ b/lib/include/elements/element/indirect.hpp
@@ -7,7 +7,6 @@
 #define ELEMENTS_REFERENCE_APRIL_10_2016
 
 #include <elements/element/element.hpp>
-#include <elements/element/proxy.hpp>
 #include <functional>
 
 namespace cycfi { namespace elements

--- a/lib/include/elements/element/margin.hpp
+++ b/lib/include/elements/element/margin.hpp
@@ -8,6 +8,7 @@
 
 #include <elements/element/proxy.hpp>
 #include <elements/support/context.hpp>
+#include <infra/support.hpp>
 #include <memory>
 
 namespace cycfi { namespace elements
@@ -22,8 +23,8 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              margin_element(Rect margin_, Subject&& subject)
-                               : base_type(std::forward<Subject>(subject))
+                              margin_element(Rect margin_, Subject subject)
+                               : base_type(std::move(subject))
                                , _margin(margin_)
                               {}
 
@@ -76,7 +77,7 @@ namespace cycfi { namespace elements
    ////////////////////////////////////////////////////////////////////////////
    // Full Margin
    template <typename Subject>
-   inline margin_element<rect, Subject>
+   inline margin_element<rect, remove_cvref_t<Subject>>
    margin(rect margin_, Subject&& subject)
    {
       return { margin_, std::forward<Subject>(subject) };
@@ -91,7 +92,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline margin_element<left_margin_rect, Subject>
+   inline margin_element<left_margin_rect, remove_cvref_t<Subject>>
    left_margin(left_margin_rect margin_, Subject&& subject)
    {
       return { margin_, std::forward<Subject>(subject) };
@@ -106,7 +107,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline margin_element<right_margin_rect, Subject>
+   inline margin_element<right_margin_rect, remove_cvref_t<Subject>>
    right_margin(right_margin_rect margin_, Subject&& subject)
    {
       return { margin_, std::forward<Subject>(subject) };
@@ -121,7 +122,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline margin_element<top_margin_rect, Subject>
+   inline margin_element<top_margin_rect, remove_cvref_t<Subject>>
    top_margin(top_margin_rect margin_, Subject&& subject)
    {
       return { margin_, std::forward<Subject>(subject) };
@@ -136,7 +137,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline margin_element<bottom_margin_rect, Subject>
+   inline margin_element<bottom_margin_rect, remove_cvref_t<Subject>>
    bottom_margin(bottom_margin_rect margin_, Subject&& subject)
    {
       return { margin_, std::forward<Subject>(subject) };
@@ -152,7 +153,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline margin_element<left_top_margin_rect, Subject>
+   inline margin_element<left_top_margin_rect, remove_cvref_t<Subject>>
    left_top_margin(left_top_margin_rect margin_, Subject&& subject)
    {
       return { margin_, std::forward<Subject>(subject) };
@@ -169,7 +170,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline margin_element<xside_margin_rect, Subject>
+   inline margin_element<xside_margin_rect, remove_cvref_t<Subject>>
    xside_margin(xside_margin_rect margin_, Subject&& subject)
    {
       return { margin_, std::forward<Subject>(subject) };
@@ -186,7 +187,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline margin_element<yside_margin_rect, Subject>
+   inline margin_element<yside_margin_rect, remove_cvref_t<Subject>>
    yside_margin(yside_margin_rect margin_, Subject&& subject)
    {
       return { margin_, std::forward<Subject>(subject) };

--- a/lib/include/elements/element/menu.hpp
+++ b/lib/include/elements/element/menu.hpp
@@ -11,6 +11,7 @@
 #include <elements/element/popup.hpp>
 #include <elements/element/selectable.hpp>
 #include <elements/view.hpp>
+#include <infra/support.hpp>
 
 namespace cycfi { namespace elements
 {
@@ -125,7 +126,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline proxy<Subject, basic_menu_item_element>
+   inline proxy<remove_cvref_t<Subject>, basic_menu_item_element>
    basic_menu_item(Subject&& subject)
    {
       return { std::forward<Subject>(subject) };

--- a/lib/include/elements/element/misc.hpp
+++ b/lib/include/elements/element/misc.hpp
@@ -11,6 +11,7 @@
 #include <elements/element/text.hpp>
 #include <elements/support/theme.hpp>
 #include <elements/support/font.hpp>
+#include <infra/support.hpp>
 #include <functional>
 #include <string>
 #include <string_view>
@@ -400,8 +401,8 @@ namespace cycfi { namespace elements
    {
       using base_type = proxy<Subject>;
 
-                              key_intercept_element(Subject&& subject)
-                               : base_type(std::forward<Subject>(subject))
+                              key_intercept_element(Subject subject)
+                               : base_type(std::move(subject))
                               {}
 
       bool                    key(context const& ctx, key_info k) override;
@@ -414,7 +415,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline key_intercept_element<Subject>
+   inline key_intercept_element<remove_cvref_t<Subject>>
    key_intercept(Subject&& subject)
    {
       return { std::forward<Subject>(subject) };

--- a/lib/include/elements/element/popup.hpp
+++ b/lib/include/elements/element/popup.hpp
@@ -8,6 +8,7 @@
 
 #include <elements/element/floating.hpp>
 #include <elements/view.hpp>
+#include <infra/support.hpp>
 
 namespace cycfi { namespace elements
 {
@@ -37,7 +38,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline proxy<Subject, basic_popup_element>
+   inline proxy<remove_cvref_t<Subject>, basic_popup_element>
    basic_popup(Subject&& subject, rect bounds = {})
    {
       return { std::forward<Subject>(subject), bounds };

--- a/lib/include/elements/element/port.hpp
+++ b/lib/include/elements/element/port.hpp
@@ -7,6 +7,7 @@
 #define ELEMENTS_PORT_APRIL_24_2016
 
 #include <elements/element/proxy.hpp>
+#include <infra/support.hpp>
 #include <memory>
 
 namespace cycfi { namespace elements
@@ -51,7 +52,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline proxy<Subject, port_element>
+   inline proxy<remove_cvref_t<Subject>, port_element>
    port(Subject&& subject)
    {
       return { std::forward<Subject>(subject) };
@@ -80,7 +81,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline proxy<Subject, vport_element>
+   inline proxy<remove_cvref_t<Subject>, vport_element>
    vport(Subject&& subject)
    {
       return { std::forward<Subject>(subject) };
@@ -193,21 +194,21 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline proxy<Subject, scroller_base>
+   inline proxy<remove_cvref_t<Subject>, scroller_base>
    scroller(Subject&& subject, int traits = 0)
    {
       return { std::forward<Subject>(subject), traits };
    }
 
    template <typename Subject>
-   inline proxy<Subject, scroller_base>
+   inline proxy<remove_cvref_t<Subject>, scroller_base>
    vscroller(Subject&& subject, int traits = 0)
    {
       return { std::forward<Subject>(subject), traits | no_hscroll };
    }
 
    template <typename Subject>
-   inline proxy<Subject, scroller_base>
+   inline proxy<remove_cvref_t<Subject>, scroller_base>
    hscroller(Subject&& subject, int traits = 0)
    {
       return { std::forward<Subject>(subject), traits | no_vscroll };

--- a/lib/include/elements/element/proxy.hpp
+++ b/lib/include/elements/element/proxy.hpp
@@ -65,26 +65,35 @@ namespace cycfi { namespace elements
 
       static_assert(std::is_base_of_v<proxy_base, Base>,
          "proxy Base type needs to be or inherit from proxy_base");
-      using subject_type = typename std::decay<Subject>::type;
+      static_assert(!std::is_reference_v<Subject>,
+         "Subject must not be a reference type - maybe you want to use reference class instead");
+      static_assert(!std::is_const_v<Subject>, "Subject must not be const");
 
                               template <typename... T>
-                              proxy(Subject&& subject_, T&&... args)
+                              proxy(Subject subject_, T&&... args)
                                : Base(std::forward<T>(args)...)
-                               , _subject(std::forward<Subject>(subject_)) {}
+                               , _subject(std::move(subject_)) {}
 
       void                    subject(Subject&& subject_);
+      void                    subject(Subject const& subject_);
       element const&          subject() const override { return _subject; }
       element&                subject() override { return _subject; }
 
    private:
 
-      subject_type            _subject;
+      Subject                 _subject;
    };
 
    template <typename Subject, typename Base>
    inline void proxy<Subject, Base>::subject(Subject&& subject_)
    {
-      _subject = std::forward<Subject>(subject_);
+      _subject = std::move(subject_);
+   }
+
+   template <typename Subject, typename Base>
+   inline void proxy<Subject, Base>::subject(Subject const& subject_)
+   {
+      _subject = subject_;
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/lib/include/elements/element/size.hpp
+++ b/lib/include/elements/element/size.hpp
@@ -8,6 +8,7 @@
 
 #include <elements/element/element.hpp>
 #include <elements/element/proxy.hpp>
+#include <infra/support.hpp>
 #include <memory>
 
 namespace cycfi { namespace elements
@@ -22,7 +23,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              size_element(point size, Subject&& subject);
+                              size_element(point size, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
@@ -36,13 +37,13 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline size_element<Subject>::size_element(point size, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline size_element<Subject>::size_element(point size, Subject subject)
+    : base_type(std::move(subject))
     , _size(size)
    {}
 
    template <typename Subject>
-   inline size_element<Subject>
+   inline size_element<remove_cvref_t<Subject>>
    fixed_size(point size, Subject&& subject)
    {
       return { size, std::forward<Subject>(subject) };
@@ -74,7 +75,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              hsize_element(float width, Subject&& subject);
+                              hsize_element(float width, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
@@ -88,13 +89,13 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline hsize_element<Subject>::hsize_element(float width, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline hsize_element<Subject>::hsize_element(float width, Subject subject)
+    : base_type(std::move(subject))
     , _width(width)
    {}
 
    template <typename Subject>
-   inline hsize_element<Subject>
+   inline hsize_element<remove_cvref_t<Subject>>
    hsize(float width, Subject&& subject)
    {
       return { width, std::forward<Subject>(subject) };
@@ -123,7 +124,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              vsize_element(float height, Subject&& subject);
+                              vsize_element(float height, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
@@ -137,13 +138,13 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline vsize_element<Subject>::vsize_element(float height, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline vsize_element<Subject>::vsize_element(float height, Subject subject)
+    : base_type(std::move(subject))
     , _height(height)
    {}
 
    template <typename Subject>
-   inline vsize_element<Subject>
+   inline vsize_element<remove_cvref_t<Subject>>
    vsize(float height, Subject&& subject)
    {
       return { height, std::forward<Subject>(subject) };
@@ -174,7 +175,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              min_size_element(point size, Subject&& subject);
+                              min_size_element(point size, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
@@ -188,13 +189,13 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline min_size_element<Subject>::min_size_element(point size, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline min_size_element<Subject>::min_size_element(point size, Subject subject)
+    : base_type(std::move(subject))
     , _size(size)
    {}
 
    template <typename Subject>
-   inline min_size_element<Subject>
+   inline min_size_element<remove_cvref_t<Subject>>
    min_size(point size, Subject&& subject)
    {
       return { size, std::forward<Subject>(subject) };
@@ -228,7 +229,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              hmin_size_element(float width, Subject&& subject);
+                              hmin_size_element(float width, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
@@ -242,13 +243,13 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline hmin_size_element<Subject>::hmin_size_element(float width, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline hmin_size_element<Subject>::hmin_size_element(float width, Subject subject)
+    : base_type(std::move(subject))
     , _width(width)
    {}
 
    template <typename Subject>
-   inline hmin_size_element<Subject>
+   inline hmin_size_element<remove_cvref_t<Subject>>
    hmin_size(float width, Subject&& subject)
    {
       return { width, std::forward<Subject>(subject) };
@@ -278,7 +279,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              vmin_size_element(float height, Subject&& subject);
+                              vmin_size_element(float height, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
@@ -292,13 +293,13 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline vmin_size_element<Subject>::vmin_size_element(float height, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline vmin_size_element<Subject>::vmin_size_element(float height, Subject subject)
+    : base_type(std::move(subject))
     , _height(height)
    {}
 
    template <typename Subject>
-   inline vmin_size_element<Subject>
+   inline vmin_size_element<remove_cvref_t<Subject>>
    vmin_size(float height, Subject&& subject)
    {
       return { height, std::forward<Subject>(subject) };
@@ -330,7 +331,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              max_size_element(point size, Subject&& subject);
+                              max_size_element(point size, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
@@ -344,13 +345,13 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline max_size_element<Subject>::max_size_element(point size, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline max_size_element<Subject>::max_size_element(point size, Subject subject)
+    : base_type(std::move(subject))
     , _size(size)
    {}
 
    template <typename Subject>
-   inline max_size_element<Subject>
+   inline max_size_element<remove_cvref_t<Subject>>
    max_size(point size, Subject&& subject)
    {
       return { size, std::forward<Subject>(subject) };
@@ -384,7 +385,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              hmax_size_element(float size, Subject&& subject);
+                              hmax_size_element(float size, Subject subject);
 
       view_limits             limits(basic_context const& ctx) const override;
       void                    prepare_subject(context& ctx) override;
@@ -398,13 +399,13 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline hmax_size_element<Subject>::hmax_size_element(float size, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline hmax_size_element<Subject>::hmax_size_element(float size, Subject subject)
+    : base_type(std::move(subject))
     , _size(size)
    {}
 
    template <typename Subject>
-   inline hmax_size_element<Subject>
+   inline hmax_size_element<remove_cvref_t<Subject>>
    hmax_size(float size, Subject&& subject)
    {
       return { size, std::forward<Subject>(subject) };
@@ -436,7 +437,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              hstretch_element(float stretch, Subject&& subject);
+                              hstretch_element(float stretch, Subject subject);
 
       virtual view_stretch    stretch() const;
 
@@ -449,8 +450,8 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline hstretch_element<Subject>::hstretch_element(float stretch, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline hstretch_element<Subject>::hstretch_element(float stretch, Subject subject)
+    : base_type(std::move(subject))
     , _stretch(stretch)
    {}
 
@@ -461,17 +462,17 @@ namespace cycfi { namespace elements
    }
 
    template <typename Subject>
-   inline hstretch_element<Subject>
+   inline hstretch_element<remove_cvref_t<Subject>>
    hstretch(float stretch, Subject&& subject)
    {
       return { stretch, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline hstretch_element<Subject>
+   inline auto
    no_hstretch(Subject&& subject)
    {
-      return { 0.0f, std::forward<Subject>(subject) };
+      return hstretch(0.0f, std::forward<Subject>(subject));
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -482,7 +483,7 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              vstretch_element(float stretch, Subject&& subject);
+                              vstretch_element(float stretch, Subject subject);
 
       virtual view_stretch    stretch() const;
 
@@ -495,8 +496,8 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline vstretch_element<Subject>::vstretch_element(float stretch, Subject&& subject)
-    : base_type(std::forward<Subject>(subject))
+   inline vstretch_element<Subject>::vstretch_element(float stretch, Subject subject)
+    : base_type(std::move(subject))
     , _stretch(stretch)
    {}
 
@@ -507,17 +508,17 @@ namespace cycfi { namespace elements
    }
 
    template <typename Subject>
-   inline vstretch_element<Subject>
+   inline vstretch_element<remove_cvref_t<Subject>>
    vstretch(float stretch, Subject&& subject)
    {
       return { stretch, std::forward<Subject>(subject) };
    }
 
    template <typename Subject>
-   inline vstretch_element<Subject>
+   inline auto
    no_vstretch(Subject&& subject)
    {
-      return { 0.0f, std::forward<Subject>(subject) };
+      return vstretch(0.0f, std::forward<Subject>(subject));
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -530,8 +531,8 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              limit_element(view_limits limits_, Subject&& subject)
-                               : base_type(std::forward<Subject>(subject))
+                              limit_element(view_limits limits_, Subject subject)
+                               : base_type(std::move(subject))
                                , _limits(limits_)
                               {}
 
@@ -546,7 +547,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline limit_element<Subject>
+   inline limit_element<remove_cvref_t<Subject>>
    limit(view_limits limits_, Subject&& subject)
    {
       return { limits_, std::forward<Subject>(subject) };
@@ -574,8 +575,8 @@ namespace cycfi { namespace elements
 
       using base_type = proxy<Subject>;
 
-                              scale_element(float scale_, Subject&& subject)
-                               : base_type(std::forward<Subject>(subject))
+                              scale_element(float scale_, Subject subject)
+                               : base_type(std::move(subject))
                                , _scale(scale_)
                               {}
 
@@ -594,7 +595,7 @@ namespace cycfi { namespace elements
    };
 
    template <typename Subject>
-   inline scale_element<Subject>
+   inline scale_element<remove_cvref_t<Subject>>
    scale(float scale_, Subject&& subject)
    {
       return { scale_, std::forward<Subject>(subject) };

--- a/lib/include/elements/element/slider.hpp
+++ b/lib/include/elements/element/slider.hpp
@@ -10,6 +10,7 @@
 #include <elements/element/tracker.hpp>
 #include <elements/view.hpp>
 #include <elements/support.hpp>
+#include <infra/support.hpp>
 
 #include <cmath>
 #include <functional>
@@ -349,7 +350,7 @@ namespace cycfi { namespace elements
    template <
       std::size_t _size, std::size_t _num_divs = 50
     , std::size_t _major_divs = 10, typename Subject>
-   inline slider_marks_element<_size, _num_divs, _major_divs, Subject>
+   inline slider_marks_element<_size, _num_divs, _major_divs, remove_cvref_t<Subject>>
    slider_marks(Subject&& subject)
    {
       return {std::forward<Subject>(subject)};
@@ -369,10 +370,10 @@ namespace cycfi { namespace elements
       using string_array = std::array<std::string, num_labels>;
 
                               slider_labels_element(
-                                 Subject&& subject
+                                 Subject subject
                                , float font_size
                               )
-                               : base_type(std::forward<Subject>(subject))
+                               : base_type(std::move(subject))
                                , _font_size(font_size)
                               {}
 
@@ -405,10 +406,10 @@ namespace cycfi { namespace elements
    }
 
    template <int size, typename Subject, typename... S>
-   inline slider_labels_element<size, Subject, sizeof...(S)>
+   inline slider_labels_element<size, remove_cvref_t<Subject>, sizeof...(S)>
    slider_labels(Subject&& subject, float font_size, S&&... s)
    {
-      auto r = slider_labels_element<size, Subject, sizeof...(S)>
+      auto r = slider_labels_element<size, remove_cvref_t<Subject>, sizeof...(S)>
          {std::forward<Subject>(subject), font_size};
       r._labels = {{ std::move(s)... }};
       return r;


### PR DESCRIPTION
- update infra to get remove_cvref transformation trait
- change proxy type to only accept non-const non-reference types
- correct all proxy factories to instantiate proxy with
  non-const non-reference type while keeping perfect forwarding
- remove/repair all broken forwarding in non-deduced contexts