### PR TITLE
Allow to set custom paths for fonts

### DIFF
--- a/lib/include/elements/support/font.hpp
+++ b/lib/include/elements/support/font.hpp
@@ -8,6 +8,7 @@
 
 #include <string_view>
 #include <infra/filesystem.hpp>
+#include <vector>
 
 extern "C"
 {
@@ -308,6 +309,8 @@ namespace cycfi { namespace elements
 #ifdef __APPLE__
    fs::path get_user_fonts_directory();
 #endif
+
+   extern std::vector<fs::path> font_paths;
 }}
 
 #endif

--- a/lib/include/elements/support/font.hpp
+++ b/lib/include/elements/support/font.hpp
@@ -310,7 +310,7 @@ namespace cycfi { namespace elements
    fs::path get_user_fonts_directory();
 #endif
 
-   extern std::vector<fs::path> font_paths;
+   std::vector<fs::path>& font_paths();
 }}
 
 #endif

--- a/lib/include/elements/support/theme.hpp
+++ b/lib/include/elements/support/theme.hpp
@@ -124,7 +124,7 @@ namespace cycfi { namespace elements
       friend scoped_theme_override<T>
       override_theme(T theme::*pmem, T val);
 
-      static theme _theme;
+      static theme& _theme();
    };
 
    template <typename T>
@@ -132,7 +132,7 @@ namespace cycfi { namespace elements
    override_theme(T theme::*pmem, T val)
    {
       return scoped_theme_override<T>{
-         global_theme::_theme, pmem, val
+         global_theme::_theme(), pmem, val
       };
    }
 }}

--- a/lib/src/support/font.cpp
+++ b/lib/src/support/font.cpp
@@ -150,18 +150,22 @@ namespace cycfi { namespace elements
       {
          FcConfig*      config = FcInitLoadConfigAndFonts();
 
+         std::vector<fs::path> paths = font_paths;
+
 #ifdef __APPLE__
-         auto resources_path = get_user_fonts_directory();
+         paths.push_back(get_user_fonts_directory());
 #else
-         auto resources_path = (fs::current_path() / "resources").generic_string();
+         if (paths.empty())
+            paths.push_back(fs::current_path() / "resources");
 #if defined(ELEMENTS_HOST_UI_LIBRARY_WIN32)
          TCHAR windir[MAX_PATH];
          GetWindowsDirectory(windir, MAX_PATH);
-         auto fonts_path = (fs::path(windir) / "fonts").generic_string();
-         FcConfigAppFontAddDir(config, (FcChar8 const*)fonts_path.c_str());
+         paths.push_back(fs::path(windir) / "fonts");
 #endif
 #endif
-         FcConfigAppFontAddDir(config, (FcChar8 const*)resources_path.c_str());
+         for (auto& path : paths)
+            FcConfigAppFontAddDir(config, (FcChar8*)path.generic_string().c_str());
+
          FcPattern*     pat = FcPatternCreate();
          FcObjectSet*   os = FcObjectSetBuild(
                                  FC_FAMILY, FC_FULLNAME, FC_WIDTH, FC_WEIGHT
@@ -272,6 +276,8 @@ namespace cycfi { namespace elements
       };
 #endif
    }
+
+   std::vector<fs::path> font_paths;
 
    font::font(font_descr descr)
    {

--- a/lib/src/support/font.cpp
+++ b/lib/src/support/font.cpp
@@ -150,7 +150,7 @@ namespace cycfi { namespace elements
       {
          FcConfig*      config = FcInitLoadConfigAndFonts();
 
-         std::vector<fs::path> paths = font_paths;
+         std::vector<fs::path> paths = font_paths();
 
 #ifdef __APPLE__
          paths.push_back(get_user_fonts_directory());
@@ -277,7 +277,11 @@ namespace cycfi { namespace elements
 #endif
    }
 
-   std::vector<fs::path> font_paths;
+   std::vector<fs::path>& font_paths()
+   {
+      static std::vector<fs::path> _paths;
+      return _paths;
+   }
 
    font::font(font_descr descr)
    {

--- a/lib/src/support/font.cpp
+++ b/lib/src/support/font.cpp
@@ -164,7 +164,7 @@ namespace cycfi { namespace elements
 #endif
 #endif
          for (auto& path : paths)
-            FcConfigAppFontAddDir(config, (FcChar8*)path.generic_string().c_str());
+            FcConfigAppFontAddDir(config, reinterpret_cast<FcChar8 const*>(path.generic_string().c_str()));
 
          FcPattern*     pat = FcPatternCreate();
          FcObjectSet*   os = FcObjectSetBuild(

--- a/lib/src/support/theme.cpp
+++ b/lib/src/support/theme.cpp
@@ -73,15 +73,19 @@ namespace cycfi { namespace elements
    }
 
    // The global theme
-   theme global_theme::_theme;
+   theme& global_theme::_theme()
+   {
+      static theme thm;
+      return thm;
+   }
 
    theme const& get_theme()
    {
-      return global_theme::_theme;
+      return global_theme::_theme();
    }
 
    void set_theme(theme const& thm)
    {
-      global_theme::_theme = thm;
+      global_theme::_theme() = thm;
    }
 }}


### PR DESCRIPTION
#123

This adds a variable `font_paths` for setting custom paths.
It has to be set early, before the program initializes the font map.

A problem is that the global theme is statically initialized, and so is the font map as a consequence.
I replace the global theme static in order to make it lazily instantiated.