### PR TITLE
Adapt docs files to be viewed locally

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,6 +1,7 @@
 _site
+.bundle
 .sass-cache
 .jekyll-metadata
 /Gemfile.lock
-/Gemfile
 /404.html
+*.code-workspace

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,21 @@
+source "https://rubygems.org"
+
+# Force gh-pages compatibility in RVM without gh-pages installed
+# see https://pages.github.com/versions/
+ruby "2.5.3"
+
+# Uncomment to build our site in Travis-CI
+# see https://docs.travis-ci.com/user/languages/ruby/#default-build-script
+# and https://github.com/travis-ci/travis-web/blob/master/Gemfile
+#group :development, :test do
+#  gem "rake", "~> 12"
+#end
+
+gem "jekyll", "3.8.5"
+
+group :jekyll_plugins do
+# gem "jekyll-sitemap", "1.4.0"
+  gem "jekyll-feed", "0.13.0"
+  gem "jemoji", "0.11.1"
+  gem "jekyll-theme-cayman", "0.1.1"
+end

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# [elements] documentation website source code
+
+## Test with Jekyll locally
+
+In order to test the website without having a webserver running and also see
+the changes in real time use the `jekyll.sh` script to run [Jekyll] locally from
+the current directory.
+
+It requires [ruby] to be installed; [RVM] is the preferred choice for this,
+the rest will be installed locally in the `.bundle` directory.
+
+The current Gemfile configuration is set to use the same
+Jekyll version as [GitHub pages].
+
+The website will be available at <http://localhost:4000/>.
+
+[elements]:     https://cycfi.github.io/elements/
+[Jekyll]:       https://jekyllrb.com/
+[ruby]:         https://www.ruby-lang.org/en/
+[RVM]:          http://rvm.io/
+[GitHub pages]: https://pages.github.com/versions/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,6 +14,13 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
+defaults:
+- scope:
+    path: ""
+    type: "pages"
+  values:
+    layout: "default"
+
 title: "Elements C++ GUI library"
 email: djowel@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
@@ -44,3 +51,10 @@ plugins:
 #   - vendor/gems/
 #   - vendor/ruby/
 
+# Using GitHub Jekyll v3.8.7, these are not ignored by default
+exclude:
+- elements.code-workspace
+- Gemfile
+- Gemfile.lock
+- jekyll.sh
+- README.md

--- a/docs/aspects.md
+++ b/docs/aspects.md
@@ -1,3 +1,5 @@
+---
+---
 # Design Aspects
 
 ## Table of Contents
@@ -105,7 +107,7 @@ view_.content(
 
 Running this example, you get:
 
-![aspects_a]({{ site.url }}/elements/assets/images/aspects_a.png){: width="60%" }
+![aspects_a](assets/images/aspects_a.png){: width="60%" }
 
 ## Aligns and Sizes
 
@@ -170,7 +172,7 @@ placed inside the `fixed_size` element which is then placed inside a
 
 Let's run this example:
 
-![aspects_b]({{ site.url }}/elements/assets/images/aspects_b.png){: width="60%" }
+![aspects_b](assets/images/aspects_b.png){: width="60%" }
 
 ## Labels, Margins and Layers
 
@@ -247,7 +249,7 @@ actually, this is the same `layer` thing here. The view's main content is a
 
 So now we have:
 
-![aspects_c]({{ site.url }}/elements/assets/images/aspects_c.png){: width="60%" }
+![aspects_c](assets/images/aspects_c.png){: width="60%" }
 
 ## Let's Make a Button
 
@@ -317,7 +319,7 @@ we want to center the button:
 And here it is in action:
 
 <video width="476" height="320" style="margin-left: 30px" controls loop>
-  <source type="video/mp4" src="{{ site.url }}/elements/assets/images/button.mp4">
+  <source type="video/mp4" src="assets/images/button.mp4">
 </video>
 
 Oh, hey, Elements has a gallery —a collection of reusable element
@@ -330,7 +332,7 @@ Guess what, we can make funny sliders too, using the same components we made
 in the previous sections!
 
 <video width="476" height="320" style="margin-left: 30px" controls loop>
-  <source type="video/mp4" src="{{ site.url }}/elements/assets/images/funny_slider.mp4">
+  <source type="video/mp4" src="assets/images/funny_slider.mp4">
 </video>
 
 Here's the code:

--- a/docs/context.md
+++ b/docs/context.md
@@ -1,3 +1,5 @@
+---
+---
 # Context
 
 -------------------------------------------------------------------------------
@@ -19,9 +21,17 @@ struct basic_context
    elements::canvas&    canvas;
 };
 ```
-The `context` class inherits from `basic_context` and additionally includes a pointer to the "current" element being drawn, a pointer to its parent element in the elements hierarchy (that which contains it), and the element's `bounds`, a rectangle that indicates where the element needs to be drawn.
+The `context` class inherits from `basic_context` and additionally includes a
+pointer to the "current" element being drawn, a pointer to its parent element
+in the elements hierarchy (that which contains it), and the element's `bounds`,
+a rectangle that indicates where the element needs to be drawn.
 
-Only one `element` member function takes in a `basic_context` argument, the `limits` member function (more on that later). Other than that, all the other `element` member functions take in a `context` argument. The reason for this is that the at the point where the `limits` is called, the element's position and parent-child relationships in the elements hierarchy have not been established yet.
+Only one `element` member function takes in a `basic_context` argument,
+the `limits` member function (more on that later). Other than that,
+all the other `element` member functions take in a `context` argument.
+The reason for this is that the at the point where the `limits` is called,
+the element's position and parent-child relationships in the elements hierarchy
+have not been established yet.
 
 ```c++
 class context : public basic_context

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -1,3 +1,5 @@
+---
+---
 # Gallery
 
 It’s always a nice to have some pretty pictures:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,13 @@
+---
+---
 # Elements C++ GUI library
 
-![alt Photon Sampler]({{ site.url }}/elements/assets/images/photon_sampler.jpg)
+![alt Photon Sampler](assets/images/photon_sampler.jpg)
 
 ## Introduction
 
-Elements is a lightweight, fine-grained, resolution independent, modular GUI library. Elements is designed with these requirements in mind:
+Elements is a lightweight, fine-grained, resolution independent,
+modular GUI library. Elements is designed with these requirements in mind:
 
 1. It should be open source with a liberal, non-viral license.
 2. It should be usable in any application and should play well with other GUI
@@ -25,13 +28,13 @@ declarative interface with heavy emphasis on reuse.
 ## Documentation
 
 1. [Gallery](gallery)
-2. [Setup and Installation](http://cycfi.github.io/elements/setup)
-3. [Design Aspects](http://cycfi.github.io/elements/aspects)
-4. [Layout](http://cycfi.github.io/elements/layout)
+2. [Setup and Installation](setup)
+3. [Design Aspects](aspects)
+4. [Layout](layout)
 
 The Elements C++ GUI library is cross-platform. Elements currently supports
 the MacOS, Windows and Linux. Follow the [Setup and Installation
-guide](http://cycfi.github.io/elements/setup) to get started using the
+guide](setup) to get started using the
 library.
 
 ## <a name="jdeguzman"></a>About the Author

--- a/docs/jekyll.sh
+++ b/docs/jekyll.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -d ".bundle" ]; then
+	gem update
+	gem install bundler
+	bundle config set path '.bundle'
+	bundle install
+fi
+
+bundle exec jekyll serve --watch --host=0.0.0.0

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1,3 +1,5 @@
+---
+---
 # Layout
 
 ## Table of Contents
@@ -143,7 +145,7 @@ elements.
 
 ### limit
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/limit.png">
+<img width="40%" height="40%" src="assets/images/layout/limit.png">
 
 Overrides the *limits* of an element.
 
@@ -166,7 +168,7 @@ limit(limits, subject)
 
 ### fixed_size
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/fixed_size.png">
+<img width="40%" height="40%" src="assets/images/layout/fixed_size.png">
 
 Fixes the size of an enclosed element (`subject`).
 
@@ -191,7 +193,7 @@ fixed_size({ width, height }, subject)
 
 ### hsize
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/hsize.png">
+<img width="40%" height="40%" src="assets/images/layout/hsize.png">
 
 Fixes the horizontal size of an enclosed element (`subject`).
 
@@ -217,7 +219,7 @@ hsize(width, subject)
 
 ### vsize
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/vsize.png">
+<img width="40%" height="40%" src="assets/images/layout/vsize.png">
 
 Fixes the *vertical limits* of an enclosed element (`subject`).
 
@@ -243,7 +245,7 @@ vsize(height, subject)
 
 ### min_size
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/min_size.png">
+<img width="40%" height="40%" src="assets/images/layout/min_size.png">
 
 Overrides the *minimum limits* of an enclosed element (`subject`).
 
@@ -268,7 +270,7 @@ min_size({ width, height }, subject)
 
 ### hmin_size
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/hmin_size.png">
+<img width="40%" height="40%" src="assets/images/layout/hmin_size.png">
 
 Overrides the *minimum horizontal limit* of an enclosed element (`subject`).
 
@@ -295,7 +297,7 @@ hmin_size(width, subject)
 
 ### vmin_size
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/vmin_size.png">
+<img width="40%" height="40%" src="assets/images/layout/vmin_size.png">
 
 Overrides the *minimum vertical limit* of an enclosed element (`subject`).
 
@@ -320,7 +322,7 @@ vmin_size(height, subject)
 
 ### max_size
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/max_size.png">
+<img width="40%" height="40%" src="assets/images/layout/max_size.png">
 
 Overrides the *maximum limits* of an enclosed element (`subject`).
 
@@ -345,7 +347,7 @@ max_size({ width, height }, subject)
 
 ### hmax_size
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/hmax_size.png">
+<img width="40%" height="40%" src="assets/images/layout/hmax_size.png">
 
 Overrides the *maximum horizontal limit* of an enclosed element (`subject`).
 
@@ -372,7 +374,7 @@ hmax_size(width, subject)
 
 ### vmax_size
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/vmax_size.png">
+<img width="40%" height="40%" src="assets/images/layout/vmax_size.png">
 
 Overrides the *maximum vertical limit* of an enclosed element (`subject`).
 
@@ -430,7 +432,7 @@ default 1.0 stretchiness.
 
 ### hstretch
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/hstretch.png">
+<img width="40%" height="40%" src="assets/images/layout/hstretch.png">
 
 Overrides the horizontal stretchiness of an an enclosed element (`subject`).
 
@@ -453,7 +455,7 @@ hstretch(stretch, subject)
 For example, the image below shows how three elements are laid out in an
 `htile`, with stretch values of `1.0`, `1.0` and `2.0`, respectively:
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/htile-stretch.png">
+<img width="40%" height="40%" src="assets/images/layout/htile-stretch.png">
 
 The element with the `2.0` stretch value stretches twice as much compared to
 its siblings.
@@ -462,7 +464,7 @@ its siblings.
 
 ### vstretch
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/vstretch.png">
+<img width="40%" height="40%" src="assets/images/layout/vstretch.png">
 
 Overrides the vertical stretchiness of an an enclosed element (`subject`).
 
@@ -485,7 +487,7 @@ vstretch(stretch, subject)
 For example, the image below shows how three elements are laid out in an
 `htile`, with stretch values of `0.5`, `1.0` and `1.5`, respectively:
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/vtile-stretch.png">
+<img width="40%" height="40%" src="assets/images/layout/vtile-stretch.png">
 
 The element with the `0.5` stretch value stretches half less, while the
 element with the `1.5` stretches half more than the default.
@@ -532,7 +534,7 @@ catalogues all the available align elements.
 
 ### halign
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/halign.png">
+<img width="40%" height="40%" src="assets/images/layout/halign.png">
 
 Aligns the an enclosed element (`subject`) in the x-axis.
 
@@ -562,7 +564,7 @@ halign(align, subject)
 
 ### align_left
 
-<img width="30%" height="30%" src="{{ site.url }}/elements/assets/images/layout/align_left.png">
+<img width="30%" height="30%" src="assets/images/layout/align_left.png">
 
 Left-aligns the an enclosed element (`subject`).
 
@@ -584,7 +586,7 @@ align_left(subject)
 
 ### align_center
 
-<img width="30%" height="30%" src="{{ site.url }}/elements/assets/images/layout/align_center.png">
+<img width="30%" height="30%" src="assets/images/layout/align_center.png">
 
 Center-aligns the an enclosed element (`subject`).
 
@@ -606,7 +608,7 @@ align_center(subject)
 
 ### align_right
 
-<img width="30%" height="30%" src="{{ site.url }}/elements/assets/images/layout/align_right.png">
+<img width="30%" height="30%" src="assets/images/layout/align_right.png">
 
 Right-aligns the an enclosed element (`subject`).
 
@@ -628,7 +630,7 @@ align_right(subject)
 
 ### valign
 
-<img width="20%" height="20%" src="{{ site.url }}/elements/assets/images/layout/valign.png">
+<img width="20%" height="20%" src="assets/images/layout/valign.png">
 
 Aligns the an enclosed element (`subject`) in the y-axis.
 
@@ -658,7 +660,7 @@ valign(align, subject)
 
 ### align_top
 
-<img width="15%" height="15%" src="{{ site.url }}/elements/assets/images/layout/align_top.png">
+<img width="15%" height="15%" src="assets/images/layout/align_top.png">
 
 Aligns the an enclosed element (`subject`) to the top.
 
@@ -680,7 +682,7 @@ align_top(subject)
 
 ### align_middle
 
-<img width="15%" height="15%" src="{{ site.url }}/elements/assets/images/layout/align_middle.png">
+<img width="15%" height="15%" src="assets/images/layout/align_middle.png">
 
 Aligns the an enclosed element (`subject`) to the middle.
 
@@ -702,7 +704,7 @@ align_middle(subject)
 
 ### align_bottom
 
-<img width="15%" height="15%" src="{{ site.url }}/elements/assets/images/layout/align_bottom.png">
+<img width="15%" height="15%" src="assets/images/layout/align_bottom.png">
 
 Aligns the an enclosed element (`subject`) to the bottom.
 
@@ -724,7 +726,7 @@ align_bottom(subject)
 
 ### align_left_top
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_left_top.png">
+<img width="25%" height="25%" src="assets/images/layout/align_left_top.png">
 
 Aligns the an enclosed element (`subject`) to the left-top.
 
@@ -746,7 +748,7 @@ align_left_top(subject)
 
 ### align_center_top
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_center_top.png">
+<img width="25%" height="25%" src="assets/images/layout/align_center_top.png">
 
 Aligns the an enclosed element (`subject`) to the center-top.
 
@@ -768,7 +770,7 @@ align_center_top(subject)
 
 ### align_right_top
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_right_top.png">
+<img width="25%" height="25%" src="assets/images/layout/align_right_top.png">
 
 Aligns the an enclosed element (`subject`) to the right-top.
 
@@ -790,7 +792,7 @@ align_right_top(subject)
 
 ### align_left_middle
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_left_middle.png">
+<img width="25%" height="25%" src="assets/images/layout/align_left_middle.png">
 
 Aligns the an enclosed element (`subject`) to the left-middle.
 
@@ -812,7 +814,7 @@ align_left_middle(subject)
 
 ### align_center_middle
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_center_middle.png">
+<img width="25%" height="25%" src="assets/images/layout/align_center_middle.png">
 
 Aligns the an enclosed element (`subject`) to the center-middle.
 
@@ -834,7 +836,7 @@ align_center_middle(subject)
 
 ### align_right_middle
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_right_middle.png">
+<img width="25%" height="25%" src="assets/images/layout/align_right_middle.png">
 
 Aligns the an enclosed element (`subject`) to the right-middle.
 
@@ -856,7 +858,7 @@ align_right_middle(subject)
 
 ### align_left_bottom
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_left_bottom.png">
+<img width="25%" height="25%" src="assets/images/layout/align_left_bottom.png">
 
 Aligns the an enclosed element (`subject`) to the left-bottom.
 
@@ -878,7 +880,7 @@ align_left_bottom(subject)
 
 ### align_center_bottom
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_center_bottom.png">
+<img width="25%" height="25%" src="assets/images/layout/align_center_bottom.png">
 
 Aligns the an enclosed element (`subject`) to the center-bottom.
 
@@ -900,7 +902,7 @@ align_center_bottom(subject)
 
 ### align_right_bottom
 
-<img width="25%" height="25%" src="{{ site.url }}/elements/assets/images/layout/align_right_bottom.png">
+<img width="25%" height="25%" src="assets/images/layout/align_right_bottom.png">
 
 Aligns the an enclosed element (`subject`) to the right-bottom.
 
@@ -930,7 +932,7 @@ purposes. This section catalogues all the available margin elements.
 
 ### margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/margin.png">
+<img width="40%" height="40%" src="assets/images/layout/margin.png">
 
 Adds a margin all around an enclosed element (`subject`).
 
@@ -957,7 +959,7 @@ margin({ left, top, right, bottom }, subject)
 
 ### left_margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/left_margin.png">
+<img width="40%" height="40%" src="assets/images/layout/left_margin.png">
 
 Adds a margin to the left of an enclosed element (`subject`).
 
@@ -984,7 +986,7 @@ left_margin(left, subject)
 
 ### right_margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/right_margin.png">
+<img width="40%" height="40%" src="assets/images/layout/right_margin.png">
 
 Adds a margin to the right of an enclosed element (`subject`).
 
@@ -1011,7 +1013,7 @@ right_margin(right, subject)
 
 ### top_margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/top_margin.png">
+<img width="40%" height="40%" src="assets/images/layout/top_margin.png">
 
 Adds a margin to the top of an enclosed element (`subject`).
 
@@ -1038,7 +1040,7 @@ top_margin(top, subject)
 
 ### bottom_margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/bottom_margin.png">
+<img width="40%" height="40%" src="assets/images/layout/bottom_margin.png">
 
 Adds a margin to the bottom of an enclosed element (`subject`).
 
@@ -1067,7 +1069,7 @@ bottom_margin(bottom, subject)
 ### hmargin
 (same as `left_right_margin`)
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/hmargin.png">
+<img width="40%" height="40%" src="assets/images/layout/hmargin.png">
 
 Adds a margin to the left and right sides of an enclosed element (`subject`).
 
@@ -1106,7 +1108,7 @@ left_right_margin(left, right, subject)
 ### vmargin
 (same as `top_bottom_margin`)
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/vmargin.png">
+<img width="40%" height="40%" src="assets/images/layout/vmargin.png">
 
 Adds a margin to the top and bottom sides of an enclosed element (`subject`).
 
@@ -1144,7 +1146,7 @@ top_bottom_margin(top, bottom, subject)
 
 ### left_top_margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/left_top_margin.png">
+<img width="40%" height="40%" src="assets/images/layout/left_top_margin.png">
 
 Adds a margin to the left and top sides of an enclosed element (`subject`).
 
@@ -1176,7 +1178,7 @@ left_top_margin(left, top, subject)
 
 ### left_bottom_margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/left_bottom_margin.png">
+<img width="40%" height="40%" src="assets/images/layout/left_bottom_margin.png">
 
 Adds a margin to the left and bottom sides of an enclosed element (`subject`).
 
@@ -1208,7 +1210,7 @@ left_bottom_margin(left, bottom, subject)
 
 ### right_top_margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/right_top_margin.png">
+<img width="40%" height="40%" src="assets/images/layout/right_top_margin.png">
 
 Adds a margin to the right and top sides of an enclosed element (`subject`).
 
@@ -1240,7 +1242,7 @@ right_top_margin(right, top, subject)
 
 ### right_bottom_margin
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/right_top_margin.png">
+<img width="40%" height="40%" src="assets/images/layout/right_top_margin.png">
 
 Adds a margin to the right and bottom sides of an enclosed element (`subject`).
 
@@ -1272,7 +1274,7 @@ right_bottom_margin(right, bottom, subject)
 
 ## Floating
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/floating.png">
+<img width="40%" height="40%" src="assets/images/layout/floating.png">
 
 A floating element allows arbitrary placement of an enclosed element
 (`subject`) in the main view.
@@ -1313,7 +1315,7 @@ for composing UI elements while grids are best for composing tables.
 
 ### Horizontal Grids
 
-<img width="60%" height="60%" src="{{ site.url }}/elements/assets/images/layout/hgrid.png">
+<img width="60%" height="60%" src="assets/images/layout/hgrid.png">
 
 Horizontal Grids are composites that lay out one or more child elements in a
 row following externally supplied horizontal fractional positions. Horizontal
@@ -1438,7 +1440,7 @@ build complex hierarchical structures.
 
 ### Horizontal Tiles
 
-<img width="60%" height="60%" src="{{ site.url }}/elements/assets/images/layout/htile.png">
+<img width="60%" height="60%" src="assets/images/layout/htile.png">
 
 Horizontal Tiles are similar to Horizontal Grids, but allow elements to
 fluidly adjust horizontally depending on available space. Horizontal Tiles
@@ -1548,7 +1550,7 @@ build complex hierarchical structures.
 
 ### Vertical Grids
 
-<img width="60%" height="60%" src="{{ site.url }}/elements/assets/images/layout/vgrid.png">
+<img width="60%" height="60%" src="assets/images/layout/vgrid.png">
 
 Vertical Grids are composites that lay out one or more child elements in a
 column following externally supplied vertical fractional positions. Vertical
@@ -1672,7 +1674,7 @@ build complex hierarchical structures.
 
 ### Vertical Tiles
 
-<img width="60%" height="60%" src="{{ site.url }}/elements/assets/images/layout/vtile.png">
+<img width="60%" height="60%" src="assets/images/layout/vtile.png">
 
 Vertical Tiles are similar to Vertical Grids, but allow elements to fluidly
 adjust vertically depending on available space. Vertical Tiles are best used
@@ -1781,7 +1783,7 @@ allows you to build complex hierarchical structures.
 
 ## Layers
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/layer.png">
+<img width="40%" height="40%" src="assets/images/layout/layer.png">
 
 The Elements Library is 2D, but the z-axis pertains to top-to-bottom
 layering. Layers allow groups of elements to be placed in the z-axis where
@@ -1877,7 +1879,7 @@ allows you to build complex hierarchical structures.
 
 ### Decks
 
-<img width="40%" height="40%" src="{{ site.url }}/elements/assets/images/layout/deck.png">
+<img width="40%" height="40%" src="assets/images/layout/deck.png">
 
 The Deck is very similar to layers. Elements are placed in the z-axis. But
 unlike layers, only selected element is active (top-most by default).
@@ -1967,7 +1969,7 @@ height of each row is determined by the *maximum vertical limit* of all the
 elements to be laid out in that row. The following graphic depicts a
 simplified layout scenario for child elements `a` to `r`.
 
-<img width="60%" height="60%" src="{{ site.url }}/elements/assets/images/layout/flow.png">
+<img width="60%" height="60%" src="assets/images/layout/flow.png">
 
 The child elements arranged in a `flow` composite are automatically re-flowed
 (re-lay-out) when the view size changes.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,3 +1,5 @@
+---
+---
 # Setup and Installation
 
 ## Table of Contents
@@ -69,7 +71,7 @@ instructions are provided below for specific environments.
 
 ## MacOS
 
-### Install required libraries using [Homebrew](https://brew.sh/):
+### Install required libraries using [Homebrew]:
 
 ```
 brew install cairo
@@ -88,7 +90,7 @@ brew install cmake
 There are multiple ways to generate a project file using CMake depending on
 your platform and desired IDE, but here are some examples for the MacOS:
 
-### Using [XCode](https://developer.apple.com/xcode/):
+### Using [XCode]:
 
 1. CD to the elements library.
 2. Make a build directory inside the elements directory.
@@ -106,7 +108,7 @@ If successful, cmake will generate an XCode project in the build directory.
 Open the project file elements.xcodeproj and build all. You should see a
 couple of example applications.
 
-### Using [CLion](https://www.jetbrains.com/clion/):
+### Using [CLion]:
 
 Simply open the CMakeLists.txt file using CLion and build the project.
 
@@ -124,7 +126,7 @@ The only thing you have to install is Boost:
 
 #### Download and build Boost
 
-From (https://www.boost.org/users/download/), get the latest Boost version.
+From (<https://www.boost.org/users/download/>), get the latest Boost version.
 If you have it already, make sure you have version 1.68 or higher. Many Boost
 libraries are header-only. You only need to build some of the non-header-only
 libraries:
@@ -175,7 +177,8 @@ couple of example applications.
 
 #### NMake
 
-0. Open a *Command Prompt for VS 2019* ({x64/x86-64} {Native/Cross} Tools Command Prompt for VS 2019) in your start menu.
+0. Open a *Command Prompt for VS 2019*
+({x64/x86-64} {Native/Cross} Tools Command Prompt for VS 2019) in your start menu.
 1. CD to the elements library.
 2. Make a build directory inside the elements directory.
 3. CD to the build directory.
@@ -190,8 +193,8 @@ cmake -G"NMake Makefiles" -DBOOST_ROOT=path/to/boost ..//
 
 *Replace path/to/boost with the directory where you installed boost.*
 
-If successful, cmake will generate NMake Make files in the build directory. Invoke `nmake`
-to build the binary.
+If successful, cmake will generate NMake Make files in the build directory.
+Invoke `nmake` to build the binary.
 
 -------------------------------------------------------------------------------
 
@@ -200,9 +203,11 @@ to build the binary.
 ### Install MSYS2 toolchain and required libraries
 > MSYS2 is a software distro and building platform for Windows
 
-Download MSYS2 from its [official website](https://www.msys2.org/) and install it. Its installation guide is on the [home page](https://www.msys2.org/).
+Download MSYS2 from its [official website](https://www.msys2.org/) and install it.
+Its installation guide is on the [home page](https://www.msys2.org/).
 
-Open `MSYS2 MinGW 64-bit` or `MSYS2 MinGW 32-bit` from your start menu. Install tools and libraries:
+Open `MSYS2 MinGW 64-bit` or `MSYS2 MinGW 32-bit` from your start menu.
+Install tools and libraries:
 ```
 pacman -S ${MINGW_PACKAGE_PREFIX}-toolchain
 pacman -S ${MINGW_PACKAGE_PREFIX}-boost
@@ -238,7 +243,7 @@ cmake ../ -G "Unix Makefiles" -DHOST_UI_LIBRARY=gtk
 
 If successful, cmake will generate Unix Make files in the build directory.
 
-### Using [CLion](https://www.jetbrains.com/clion/):
+### Using [CLion]:
 
 Simply open the CMakeLists.txt file using CLion and build the project.
 
@@ -247,7 +252,7 @@ Simply open the CMakeLists.txt file using CLion and build the project.
 
 ## Linux
 
-### Install required libraries using [apt-get](https://linux.die.net/man/8/apt-get) (requires `sudo`).
+### Install required libraries using [apt-get] (requires `sudo`)
 
 In addition to the requirements listed in the [requirements](#requirements)
 section, the [GTK3 library](https://www.gtk.org/) is also required by the
@@ -286,7 +291,7 @@ cmake -G "Unix Makefiles" ../
 
 If successful, cmake will generate Unix Make files in the build directory.
 
-### Using [CLion](https://www.jetbrains.com/clion/):
+### Using [CLion]:
 
 Simply open the CMakeLists.txt file using CLion and build the project.
 
@@ -295,7 +300,7 @@ Simply open the CMakeLists.txt file using CLion and build the project.
 ## Building and Running the examples
 
 <div class = "img-align-right" style="width:35%">
-  <img src="{{ site.url }}/elements/assets/images/examples.png" alt="Examples">
+  <img src="assets/images/examples.png" alt="Examples">
   <p>CLion Project Tool Window</p>
 </div>
 
@@ -339,3 +344,8 @@ alongside the "hello_universe" example directory you copied to:
 
 *Copyright (c) 2014-2020 Joel de Guzman. All rights reserved.*
 *Distributed under the [MIT License](https://opensource.org/licenses/MIT)*
+
+[apt-get]: https://linux.die.net/man/8/apt-get
+[CLion]: https://www.jetbrains.com/clion/
+[Homebrew]: https://brew.sh/
+[XCode]: https://developer.apple.com/xcode/


### PR DESCRIPTION
I haven't a way to test this online since GH permits pages only from master branch, locally it's correct, I'm not sure about the relative links if they will work correctly as is or they needs a `| relative_url` addition later.
I've added also a simple README file, some more .gitignored files (VSCode works good with Jekyll) and a convenient bash script to install and run things under a Linux environment (locally at least here on ArchLinux using RVM).
The added Gemfile is required to install bundler and other dependencies required to run Jekyll.
See #130.