### PR TITLE
Replace missing Shcore library

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Elements, is extremely lightweight… and modular. You compose very
 fine-grained, flyweight “elements” to form deep element hierarchies using a
 declarative interface with heavy emphasis on reuse.
 
+## Status
+
+Please take note that Elements is still very much in flux as we are inching
+closer towards a version 1.0 release. The API and code is still undergoing
+continuous changes, and for that matter, Elements is not yet "production
+ready". But that should not prevent you from using Elements now! It is
+already in a very usable form, and more people using it will ultimately make
+it more robust when bugs are reported and fixed. API and usability matters
+and I very much welcome suggestions and contributions. Hey, this is an open
+source project! If you like the design, concepts and ideas behind Elements, I
+very much welcome collaboration.
+
 ## News
 
 - 22 June 2020: Removed dependency on Boost. This requires some API changes to

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -295,4 +295,9 @@ if (WIN32 AND NOT MSVC)
    target_link_libraries(elements PUBLIC ws2_32)
 endif()
 
+# Replace missing Shcore library removed by WIN32_LEAN_AND_MEAN
+if (WIN32) 
+   target_link_libraries(elements PUBLIC Shcore)
+endif()
+
 add_library(cycfi::elements ALIAS elements)


### PR DESCRIPTION
The WIN32_LEAN_AND_MEAN define is needed to prevent winsock.h (Winsock 1.1) from being pulled in by windows.h which is incompatible with Asio, but it also eliminates shellscalingapi.h (and seemingly Shcore.lib) which is needed by the SetProcessDpiAwareness() function call in the Windows host App class. shellscalingapi.h is already being included in the App class, this commit will add the missing lib to the link libraries.