### PR TITLE
Update the resource path search for Linux

### DIFF
--- a/lib/host/linux/app.cpp
+++ b/lib/host/linux/app.cpp
@@ -40,11 +40,30 @@ namespace cycfi { namespace elements
       on_activate.clear();
    }
 
+   fs::path find_resources()
+   {
+      const fs::path app_path = fs::path(argv[0]);
+      const fs::path app_dir = app_path.parent_path();
+
+      if (app_dir.filename() == "bin")
+      {
+         fs::path path = app_dir.parent_path() / "share" / app_path.filename() / "resources";
+         if (fs::is_directory(path))
+            return path;
+      }
+
+      const fs::path app_resources_dir = app_dir / "resources";
+      if (fs::is_directory(app_resources_dir))
+         return app_resources_dir;
+
+      return fs::current_path() / "resources";
+   }
+
    struct init_app
    {
       init_app(std::string id)
       {
-         const fs::path resources_path = fs::current_path() / "resources";
+         const fs::path resources_path = find_resources();
          font_paths().push_back(resources_path);
          resource_paths.push_back(resources_path);
 


### PR DESCRIPTION
Modifies the Linux such that the resource path can be deduced.
Following the commit f4e0f21 which removes `config.json`.
Previously, the host would search the file `config.json`. This searches the `resources` directory instead.