### PR TITLE
Use HTTPS for the website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,7 +27,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Elements is a lightweight, fine-grained, HDPI capable, resolution
   independent, modular C++ GUI library.
 baseurl: "/elements" # the subpath of your site, e.g. /blog
-url: "http://cycfi.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://cycfi.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 # twitter_username: jekyllrb
 # github_username:  jekyll
 name: "Joel de Guzman"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -45,7 +45,7 @@
     <main id="content" class="main-content" role="main">
 
         <a href="https://github.com/cycfi/elements">
-            <img src="{{ site.url }}/elements/assets/images/elements.png" alt="Logo" />
+            <img src="assets/images/elements.png" alt="Logo" />
         </a>
 
       {{ content }}


### PR DESCRIPTION
I noticed that the website works with HTTPS but getting a warning about mixed content because the logo link using HTTP instead.

I've also adapted the `site.url` in `_config.yml`, though I think it should be removed and let Jekyll auto set it based on the current domain in use, e.g. if you'll use `elements.cycfi.com` subdomain and set it in GitHub in a [CNAME file], it will work using it.

As a side note I think it would be better to move the website pages as subdirectory in `cycfi.github.io` repository, at least IMO it doesn't mess up with the code tree, having all projects documentation in the same place.
This is what we end to do with our projects, when in the beginning I thought it was good to have each project with its own documentation in the same place, but realizing that was difficult to manage the resulting website.

[CNAME file]: https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain