### PR TITLE
Restore the app name argument on Linux

### DIFF
--- a/lib/host/linux/app.cpp
+++ b/lib/host/linux/app.cpp
@@ -78,9 +78,10 @@ namespace cycfi { namespace elements
    app::app(
       int         argc_
     , char*       argv_[]
-    , std::string // name
+    , std::string name
     , std::string id
    )
+   : _app_name(name)
    {
       argc = argc_;
       argv = argv_;


### PR DESCRIPTION
This sets also automatically the main window title.