### PR TITLE
Docs: added .editorconfig

### DIFF
--- a/docs/.editorconfig
+++ b/docs/.editorconfig
@@ -1,0 +1,5 @@
+[*.html]
+indent_size = 2
+
+[*.{css,scss,js}]
+indent_size = 4


### PR DESCRIPTION
This to define also the docs editor rules.
The HTML files results in a indentation size of 2, while js and css/scss assets in a size of 4.
In the markdown files the cpp code fragments are following the usual size of 3, so I suppose that would be also the size used in markdown itself?