### PR TITLE
Docs: minimal fixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ the MacOS, Windows and Linux. Follow the [Setup and Installation
 guide](setup) to get started using the
 library.
 
-## <a name="jdeguzman"></a>About the Author
+## About the Author
 
 Joel got into electronics and programming in the 80s because almost
 everything in music, his first love, is becoming electronic and digital.
@@ -45,13 +45,16 @@ Since then, he builds his own guitars, effect boxes and synths. He enjoys
 playing distortion-laden rock guitar, composes and produces his own music in
 his home studio.
 
-Joel de Guzman is the principal architect and engineer at [Cycfi
-Research](https://www.cycfi.com/) and a consultant at [Ciere
-Consulting](https://ciere.com/). He is a software engineer specializing in
-advanced C++ and an advocate of Open Source. He has authored a number of
-highly successful Open Source projects such as
-[Boost.Spirit](http://tinyurl.com/ydhotlaf),
-[Boost.Phoenix](http://tinyurl.com/y6vkeo5t) and
-[Boost.Fusion](http://tinyurl.com/ybn5oq9v). These libraries are all part of
-the [Boost Libraries](http://tinyurl.com/jubgged), a well respected,
-peer-reviewed, Open Source, collaborative development effort.
+Joel de Guzman is the principal architect and engineer at [Cycfi Research]
+and a consultant at [Ciere Consulting]. He is a software engineer specializing
+in advanced C++ and an advocate of Open Source. He has authored a number of
+highly successful Open Source projects such as [Boost.Spirit], [Boost.Phoenix]
+and [Boost.Fusion]. These libraries are all part of the [Boost Libraries],
+a well respected, peer-reviewed, Open Source, collaborative development effort.
+
+[Cycfi Research]:   https://www.cycfi.com/
+[Ciere Consulting]: https://ciere.com/
+[Boost.Spirit]:     https://tinyurl.com/ydhotlaf
+[Boost.Phoenix]:    https://tinyurl.com/y6vkeo5t
+[Boost.Fusion]:     https://tinyurl.com/ybn5oq9v
+[Boost Libraries]:  https://tinyurl.com/jubgged

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -9,7 +9,7 @@
 * [Scale Element](#scale-element)
 * [Align Elements](#align-elements)
 * [Margin Elements](#margin-elements)
-* [Floating](#floating-element)
+* [Floating Element](#floating-element)
 * [Tiles and Grids](#tiles-and-grids)
 * [Horizontal Grids](#horizontal-grids)
 * [Horizontal Tiles](#horizontal-tiles)
@@ -17,7 +17,7 @@
 * [Vertical Tiles](#vertical-tiles)
 * [Layers](#layers)
 * [Decks](#decks)
-* [Flow](#flow-element)
+* [Flow Element](#flow-element)
 
 -------------------------------------------------------------------------------
 The Elements Library provides a comprehensive set of elements for laying out
@@ -161,6 +161,7 @@ limit(limits, subject)
 | `subject` | Instance of `Element`      |
 
 #### Semantics
+
 1. The *limits* of `subject` will be set to the specified `limits`
    constrained by the natural *limits* of the `subject` (the natural *limits*
    of the element will not be violated).
@@ -184,6 +185,7 @@ fixed_size({ width, height }, subject)
 | `subject`          | Instance of `Element` |
 
 #### Semantics
+
 1. `subject` will be laid out with a fixed `width` and `height`, constrained
    by the natural *limits* of the `subject` (the natural *limits* of the
    element will not be violated).
@@ -209,6 +211,7 @@ hsize(width, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. `subject` will be laid out with a fixed `width`, constrained by the
    natural *horizontal limits* of the `subject` (the natural *horizontal
    limits* of the element will not be violated).
@@ -235,6 +238,7 @@ vsize(height, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. `subject` will be laid out with a fixed `height`, constrained by the
    natural *vertical limits* of the `subject` (the natural *vertical limits*
    of the element will not be violated).
@@ -261,6 +265,7 @@ min_size({ width, height }, subject)
 | `subject`          | Instance of `Element` |
 
 #### Semantics
+
 1. The *minimum limits* of `subject` will be set to the specified `width` and
    `height`, constrained by the natural *minimum limits* of the `subject`.
 2. the natural *minimum limits* of the element will not be violated.
@@ -286,6 +291,7 @@ hmin_size(width, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. The *minimum horizontal limit* of `subject` will be set to the specified
    `width` constrained by the natural *horizontal minimum limits* of the
    `subject`.
@@ -313,6 +319,7 @@ vmin_size(height, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. The *minimum vertical limit* of `subject` will be set to the specified `height`
    constrained by the natural vertical *minimum limits* of the `subject`.
 2. The natural vertical *minimum limits* of the element will not be violated.
@@ -338,6 +345,7 @@ max_size({ width, height }, subject)
 | subject            | Instance of `Element` |
 
 #### Semantics
+
 1. The *maximum limits* of `subject` will be set to the specified `width` and
    `height`, constrained by the natural *maximum limits* of the `subject`.
 2. The natural *maximum limits* of the element will not be violated.
@@ -363,6 +371,7 @@ hmax_size(width, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. The *maximum horizontal limit* of `subject` will be set to the specified
    `width` constrained by the natural *maximum horizontal limit* of the
    `subject`.
@@ -390,6 +399,7 @@ vmax_size(height, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. The *maximum vertical limit* of `subject` will be set to the specified
    `height` constrained by the natural *maximum vertical limit* of the
    `subject`
@@ -448,6 +458,7 @@ hstretch(stretch, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. The `subject` will assume the given `stretch` value.
 2. The stretch value has no effect to elements with fixed horizontal size.
 2. Returns instance of `Proxy`.
@@ -480,6 +491,7 @@ vstretch(stretch, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. The `subject` will assume the given `stretch` value.
 2. The stretch value has no effect to elements with fixed *vertical limits*.
 2. Returns instance of `Proxy`.
@@ -517,6 +529,7 @@ scale(scale_, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. The `subject` will scaled given the `scale_` value. A value > 1.0 scales
    the element up (zoom in), while a value < 1.0 scales down (zoom out).
 2. Returns instance of `Proxy`.
@@ -550,6 +563,7 @@ halign(align, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Given a total allocated space `X`, `subject` will be positioned
    horizontally to `X * align`.
 2. The `subject` will assume its *minimum horizontal limit*.
@@ -579,6 +593,7 @@ align_left(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `halign(0.0, subject)`
 2. Returns instance of `Proxy`.
 
@@ -601,6 +616,7 @@ align_center(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `halign(0.5, subject)`
 2. Returns instance of `Proxy`.
 
@@ -623,6 +639,7 @@ align_right(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `halign(1.0, subject)`
 2. Returns instance of `Proxy`.
 
@@ -646,12 +663,14 @@ valign(align, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Given a total allocated space `Y`, `subject` will be positioned vertically
    to `Y * align`.
 2. The `subject` will assume its *minimum vertical limit*.
 3. Returns instance of `Proxy`.
 
 #### Examples
+
 1. `valign(0.0) // align subject to the top`
 2. `valign(1.0) // align subject to the right`
 3. `valign(0.5) // align subject to the middle`
@@ -675,6 +694,7 @@ align_top(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `valign(0.0, subject)`
 2. Returns instance of `Proxy`.
 
@@ -697,6 +717,7 @@ align_middle(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `valign(0.5, subject)`
 2. Returns instance of `Proxy`.
 
@@ -719,6 +740,7 @@ align_bottom(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `valign(1.0, subject)`
 2. Returns instance of `Proxy`.
 
@@ -741,6 +763,7 @@ align_left_top(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_left(align_top(subject))`
 2. Returns instance of `Proxy`.
 
@@ -763,6 +786,7 @@ align_center_top(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_center(align_top(subject))`
 2. Returns instance of `Proxy`.
 
@@ -785,6 +809,7 @@ align_right_top(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_right(align_top(subject))`
 2. Returns instance of `Proxy`.
 
@@ -807,6 +832,7 @@ align_left_middle(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_left(align_middle(subject))`
 2. Returns instance of `Proxy`.
 
@@ -829,6 +855,7 @@ align_center_middle(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_center(align_middle(subject))`
 2. Returns instance of `Proxy`.
 
@@ -851,6 +878,7 @@ align_right_middle(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_right(align_middle(subject))`
 2. Returns instance of `Proxy`.
 
@@ -873,6 +901,7 @@ align_left_bottom(subject)
 | subject   | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_left(align_bottom(subject))`
 2. Returns instance of `Proxy`.
 
@@ -895,6 +924,7 @@ align_center_bottom(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_center(align_bottom(subject))`
 2. Returns instance of `Proxy`.
 
@@ -917,6 +947,7 @@ align_right_bottom(subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Equivalent to `align_right(align_bottom(subject))`
 2. Returns instance of `Proxy`.
 
@@ -948,6 +979,7 @@ margin({ left, top, right, bottom }, subject)
 | `subject`                         | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the left, top, right, and bottom of the subject with the
    given parameters.
 2. The element's *limits* is overridden to account for the additional space.
@@ -975,6 +1007,7 @@ left_margin(left, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the left of the subject with the given parameter.
 2. The element's *limits* is overridden to account for the additional space.
 3. The `left_margin` does not violate the natural *limits* of the subject.
@@ -1002,6 +1035,7 @@ right_margin(right, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the right of the subject with the given parameter.
 2. The element's *limits* is overridden to account for the additional space.
 3. The `right_margin` does not violate the natural *limits* of the subject.
@@ -1029,6 +1063,7 @@ top_margin(top, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the top of the subject with the given parameter.
 2. The element's *limits* is overridden to account for the additional space.
 3. The `top_margin` does not violate the natural *limits* of the subject.
@@ -1056,6 +1091,7 @@ bottom_margin(bottom, subject)
 | `subject`    | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the to the bottom of the subject with the given
    parameter.
 2. The element's *limits* is overridden to account for the additional space.
@@ -1067,6 +1103,7 @@ bottom_margin(bottom, subject)
 -------------------------------------------------------------------------------
 
 ### hmargin
+
 (same as `left_right_margin`)
 
 <img width="40%" height="40%" src="assets/images/layout/hmargin.png">
@@ -1095,6 +1132,7 @@ left_right_margin(left, right, subject)
 | `subject`          | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the to the left and right sides of the subject with the
    given parameters.
 2. The element's *limits* is overridden to account for the additional space.
@@ -1106,6 +1144,7 @@ left_right_margin(left, right, subject)
 -------------------------------------------------------------------------------
 
 ### vmargin
+
 (same as `top_bottom_margin`)
 
 <img width="40%" height="40%" src="assets/images/layout/vmargin.png">
@@ -1134,6 +1173,7 @@ top_bottom_margin(top, bottom, subject)
 | `subject`          | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the to the top and bottom sides of the subject with the
    given parameters.
 2. The element's *limits* is overridden to account for the additional space.
@@ -1166,6 +1206,7 @@ left_top_margin(left, top, subject)
 | `subject`          | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the to the left and top sides of the subject with the
    given parameters.
 2. The element's *limits* is overridden to account for the additional space.
@@ -1198,6 +1239,7 @@ left_bottom_margin(left, bottom, subject)
 | `subject`          | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the to the left and bottom sides of the subject with the
    given parameters.
 2. The element's *limits* is overridden to account for the additional space.
@@ -1230,6 +1272,7 @@ right_top_margin(right, top, subject)
 | `subject`          | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the to the right and top sides of the subject with the
    given parameters.
 2. The element's *limits* is overridden to account for the additional space.
@@ -1262,6 +1305,7 @@ right_bottom_margin(right, bottom, subject)
 | `subject`          | Instance of `Element` |
 
 #### Semantics
+
 1. Space is added to the to the right and bottom sides of the subject with the
    given parameters.
 2. The element's *limits* is overridden to account for the additional space.
@@ -1272,7 +1316,7 @@ right_bottom_margin(right, bottom, subject)
 
 -------------------------------------------------------------------------------
 
-## Floating
+## Floating Element
 
 <img width="40%" height="40%" src="assets/images/layout/floating.png">
 
@@ -1291,6 +1335,7 @@ floating({ left, top, right, bottom }, subject)
 | `subject`                         | Instance of `Element` |
 
 #### Semantics
+
 1. The element will be placed exactly to the specified position in the main
    view, constrained to the subject's natural *limits*.
 2. The floating element does not violate the natural *limits* of the subject.
@@ -1323,6 +1368,7 @@ Grids have computed horizontal and vertical sizes following the natural
 `limits` of its children.
 
 #### Semantics
+
 1. The elements are laid out in a single row, left to right, immediately next
    to each other with no intervening space.
 2. The elements are positioned horizontally using the supplied fractional
@@ -1377,6 +1423,7 @@ hgrid(positions, item1, item2, item3, item4)
 `hgrid_composite` (see below).
 
 #### Requirements
+
 1. The number of supplied positions and elements should match, otherwise,
    compiler error (no matching function for call to `hgrid`).
 2. The positions assume the first element is at `x=0` (it is at the left-most
@@ -1387,6 +1434,7 @@ hgrid(positions, item1, item2, item3, item4)
    this is violated.
 
 #### Semantics
+
 1. In addition to the semantics of Horizontal Grids, returns instance of
    `Composite`.
 
@@ -1427,6 +1475,7 @@ interface, it can also be `share`d like any element, which allows you to
 build complex hierarchical structures.
 
 #### Requirements
+
 1. The number of items in the external coordinates vector `positions` must match
    with the number of elements at any given time.
 2. The positions assume the first element is at `x=0` (it is at the left-most
@@ -1448,6 +1497,7 @@ are best used for composing UI elements while Horizontal Grids are best for
 composing tables.
 
 #### Semantics
+
 1. The elements are laid out in a single row, left to right, immediately next
    to each other with no intervening space.
 2. The elements are positioned horizontally using the children's natural
@@ -1508,6 +1558,7 @@ htile(item1, item2, item3, item4)
 `htile_composite` (see below).
 
 #### Semantics
+
 1. In addition to the semantics of Horizontal Tiles, returns instance of
    `Composite`.
 
@@ -1558,6 +1609,7 @@ Grids have computed horizontal and vertical sizes following the natural
 `limits` of its children.
 
 #### Semantics
+
 1. The elements are laid out in a single column, top to bottom, immediately
    next to each other with no intervening space.
 2. The elements are positioned vertically using the supplied fractional
@@ -1613,6 +1665,7 @@ vgrid(positions, item1, item2, item3, item4)
 `vgrid_composite` (see below).
 
 #### Requirements
+
 1. The number of supplied coordinates and elements should match, otherwise,
    compiler error (no matching function for call to `vgrid`).
 2. The positions assume the first element is at `x=0` (it is at the top-most
@@ -1623,6 +1676,7 @@ vgrid(positions, item1, item2, item3, item4)
    this is violated.
 
 #### Semantics
+
 1. In addition to the semantics of Vertical Grids, returns instance of
    `Composite`.
 
@@ -1661,6 +1715,7 @@ interface, it can also be `share`d like any element, which allows you to
 build complex hierarchical structures.
 
 #### Requirements
+
 1. The number of items in the external coordinates vector `positions` must match
    with the number of elements at any given time.
 2. The positions assume the first element is at `x=0` (it is at the top-most
@@ -1681,6 +1736,7 @@ adjust vertically depending on available space. Vertical Tiles are best used
 for composing UI elements while Vertical Grids are best for composing tables.
 
 #### Semantics
+
 1. The elements are laid out in a single column, left to right, immediately
    next to each other with no intervening space.
 2. The elements are positioned vertically using the children's natural
@@ -1741,6 +1797,7 @@ vtile(item1, item2, item3, item4)
 `vtile_composite` (see below).
 
 #### Semantics
+
 1. In addition to the semantics of Vertical Tiles, returns instance of
    `Composite`.
 
@@ -1790,15 +1847,16 @@ layering. Layers allow groups of elements to be placed in the z-axis where
 higher-level elements obscure or hide lower-level elements.
 
 #### Semantics
+
 1. The elements are laid out in the z-axis, top to bottom.
 2. Rendering is done bottom-up; the bottom-most elements are drawn first.
 3. UI control (such as mouse clicks) proceeds from top to bottom.
    Higher-level elements are given control priority. If a higher-level
    element does not process the event, lower-level elements are given a
    chance.
-4. The layer's *minimum limit* is computed as the minimum of the children
+4. The layer's *minimum limit* is computed as the maximum of the children
    elements' *minimum limit*s.
-5. The grid's *maximum limit* is computed as the maximum of the children
+5. The grid's *maximum limit* is computed as the minimum of the children
    elements' *maximum limit*s.
 6. The final computed minimum limit is clamped to ensure it is not greater
    than the computed maximum limit. Likewise the computed maximum limit is
@@ -1840,6 +1898,7 @@ layer(item1, item2, item3, item4)
 `layer_composite` (see below).
 
 #### Semantics
+
 1. In addition to the semantics of Layers, returns instance of `Composite`.
 
 -------------------------------------------------------------------------------
@@ -1885,6 +1944,7 @@ The Deck is very similar to layers. Elements are placed in the z-axis. But
 unlike layers, only selected element is active (top-most by default).
 
 #### Semantics
+
 1. Everything listed in the layer's *Semantics*, except 2 and 3.
 2. Only the active selected element element is drawn.
 3. Only the active selected element is given the chance to process UI control.
@@ -1919,6 +1979,7 @@ deck(item1, item2, item3, item4)
 `deck_composite` (see below).
 
 #### Requirements
+
 1. In addition to the semantics of Deck, returns instance of `Composite`.
 
 -------------------------------------------------------------------------------
@@ -1958,7 +2019,7 @@ build complex hierarchical structures.
 
 -------------------------------------------------------------------------------
 
-## Flow
+## Flow Element
 
 The flow element, is a composite that lays out its children much like the way
 text is laid out: lay out each element from left to right, fitting as much
@@ -2029,4 +2090,5 @@ flow(c)
 | `c`             | Instance of `flow_composite` |
 
 #### Semantics
+
 1. Returns instance of `Composite`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,7 +6,7 @@
 * [Requirements](#requirements)
 * [MacOS Installation](#macos)
 * [Windows Installation](#windows)
-* [Windows Installation (MinGW + Gtk)](#Windows-(MinGW-+-Gtk))
+* [Windows Installation (MinGW + Gtk)](#windows-mingw--gtk)
 * [Linux Installation](#linux)
 * [Building and Running the examples](#building-and-running-the-examples)
 * [Building Outside the Project](#building-outside-the-project)
@@ -20,14 +20,14 @@ order to use the library:
 
 1. A C++17 compiler
 2. Git
-3. [CMake](https://cmake.org/) 3.9.6 or higher
-4. [Cairo](https://cairographics.org/)
-5. [fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/)
-6. [freetype2](https://www.freetype.org/) (Windows and Linux only).
+3. [CMake] 3.9.6 or higher
+4. [Cairo]
+5. [fontconfig]
+6. [freetype2] (Windows and Linux only).
 
 Additionally, the following libraries are dragged as submodules:
 
-1. The [Cycfi infra library](https://github.com/cycfi/infra/)
+1. The [Cycfi infra library]
 
 Infra provides some basic groundwork common to Cycfi libraries, including
 Elements.
@@ -35,13 +35,11 @@ Elements.
 ### C++17
 
 Elements currently supports the MacOS, Windows and Linux. In the Mac, we
-support both [XCode](https://developer.apple.com/xcode/) IDE. Elements is
-tested with XCode 10 and XCode 11. In Windows, we support Windows 10 with
-[Visual Studio 2019](https://visualstudio.microsoft.com/vs/), although it
+support both [XCode] IDE. Elements is tested with XCode 10 and XCode 11.
+In Windows, we support Windows 10 with [Visual Studio 2019], although it
 will probably also work with older versions of the Visual Studio IDE. In
-Linux, we support both [Clang](https://clang.llvm.org/) and
-[g++](https://gcc.gnu.org/) Get the latest version with a C++17 compiler. The
-[CLion](https://www.jetbrains.com/clion/) IDE is supported on all platforms.
+Linux, we support both [Clang] and [g++]. Get the latest version with
+a C++17 compiler. The [CLion] IDE is supported on all platforms.
 
 ### Git
 
@@ -53,22 +51,23 @@ git clone --recurse-submodules  https://github.com/cycfi/elements.git
 
 ### CMake
 
-Make sure you have [CMake](https://cmake.org/) 3.9.6 or higher. Follow the
+Make sure you have [CMake] 3.9.6 or higher. Follow the
 installation procedure for your platform, or follow the instructions below
 for specific environments.
 
 ### Required Libraries
 
-Elements requires [Cairo](https://www.cairographics.org/) 1.16 or higher,
-[fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/) and
-[freetype2](https://www.freetype.org/) (on Windows and Linux). Specific
-instructions are provided below for specific environments.
+Elements requires [Cairo] 1.16 or higher, [fontconfig] and [freetype2]
+(on Windows and Linux).
+Specific instructions are provided below for specific environments.
 
 -------------------------------------------------------------------------------
 
 ## MacOS
 
-### Install required libraries using [Homebrew]:
+### Install required libraries
+
+This by using [Homebrew]:
 
 ```
 brew install cairo
@@ -86,7 +85,7 @@ brew install cmake
 There are multiple ways to generate a project file using CMake depending on
 your platform and desired IDE, but here are some examples for the MacOS:
 
-### Using [XCode]:
+### Using XCode
 
 1. CD to the elements library.
 2. Make a build directory inside the elements directory.
@@ -100,13 +99,13 @@ cd build
 cmake -GXcode ../
 ```
 
-If successful, cmake will generate an XCode project in the build directory.
+If successful, CMake will generate an [XCode] project in the build directory.
 Open the project file elements.xcodeproj and build all. You should see a
 couple of example applications.
 
-### Using [CLion]:
+### Using CLion
 
-Simply open the CMakeLists.txt file using CLion and build the project.
+Simply open the CMakeLists.txt file using [CLion] and build the project.
 
 -------------------------------------------------------------------------------
 
@@ -124,8 +123,7 @@ Follow the instructions provided here: https://cmake.org/install/
 
 ### Generating the Project using CMake
 
-Assuming you have [Visual Studio
-2019](https://visualstudio.microsoft.com/vs/) installed.
+Assuming you have [Visual Studio 2019] installed.
 
 You want NMake approach if you prefer `make`-style commandline tool, or
 `Visual Studio 2019 GUI` approach otherwise.
@@ -174,8 +172,8 @@ Invoke `nmake` to build the binary.
 ### Install MSYS2 toolchain and required libraries
 > MSYS2 is a software distro and building platform for Windows
 
-Download MSYS2 from its [official website](https://www.msys2.org/) and install it.
-Its installation guide is on the [home page](https://www.msys2.org/).
+Download [MSYS2] from its official website and install it.
+Its installation guide is on the home page.
 
 Open `MSYS2 MinGW 64-bit` or `MSYS2 MinGW 32-bit` from your start menu.
 Install tools and libraries:
@@ -197,7 +195,7 @@ pacman -S ${MINGW_PACKAGE_PREFIX}-cmake
 There are multiple ways to generate a project file using CMake depending on
 your platform and desired IDE, but here are some examples for MSYS2:
 
-### Using UNIX makefiles:
+### Using UNIX makefiles
 
 1. CD to the elements library.
 2. Make a build directory inside the elements directory.
@@ -213,20 +211,21 @@ cmake ../ -G "Unix Makefiles" -DHOST_UI_LIBRARY=gtk
 
 If successful, cmake will generate Unix Make files in the build directory.
 
-### Using [CLion]:
+### Using CLion
 
-Simply open the CMakeLists.txt file using CLion and build the project.
+Simply open the CMakeLists.txt file using [CLion] and build the project.
 
 
 -------------------------------------------------------------------------------
 
 ## Linux
 
-### Install required libraries using [apt-get] (requires `sudo`)
+### Install required libraries
 
 In addition to the requirements listed in the [requirements](#requirements)
-section, the [GTK3 library](https://www.gtk.org/) is also required by the
-Linux port of Elements.
+section, the [GTK3 library] is also required by the Linux port of Elements.
+
+On Debian and derived distributions using [apt-get] (requires `sudo`):
 
 ```
 sudo apt-get install libcairo2-dev
@@ -245,7 +244,7 @@ sudo apt-get -y install cmake
 There are multiple ways to generate a project file using CMake depending on
 your platform and desired IDE, but here are some examples for Linux:
 
-### Using UNIX makefiles:
+### Using UNIX makefiles
 
 1. CD to the elements library.
 2. Make a build directory inside the elements directory.
@@ -261,9 +260,9 @@ cmake -G "Unix Makefiles" ../
 
 If successful, cmake will generate Unix Make files in the build directory.
 
-### Using [CLion]:
+### Using CLion
 
-Simply open the CMakeLists.txt file using CLion and build the project.
+Simply open the CMakeLists.txt file using [CLion] and build the project.
 
 -------------------------------------------------------------------------------
 
@@ -310,7 +309,17 @@ alongside the "hello_universe" example directory you copied to:
 3. CD to the build directory.
 4. cmake -GXcode -DELEMENTS_ROOT="../elements" ../
 
-[apt-get]: https://linux.die.net/man/8/apt-get
-[CLion]: https://www.jetbrains.com/clion/
-[Homebrew]: https://brew.sh/
-[XCode]: https://developer.apple.com/xcode/
+[apt-get]:             https://linux.die.net/man/8/apt-get
+[Cairo]:               https://cairographics.org/
+[Clang]:               https://clang.llvm.org/
+[CLion]:               https://www.jetbrains.com/clion/
+[CMake]:               https://cmake.org/
+[Cycfi infra library]: https://github.com/cycfi/infra/
+[fontconfig]:          https://www.freedesktop.org/wiki/Software/fontconfig/
+[freetype2]:           https://www.freetype.org/
+[g++]:                 https://gcc.gnu.org/
+[GTK3 library]:        https://www.gtk.org/
+[Homebrew]:            https://brew.sh/
+[MSYS2]:               https://www.msys2.org/
+[Visual Studio 2019]:  https://visualstudio.microsoft.com/vs/
+[XCode]:               https://developer.apple.com/xcode/


### PR DESCRIPTION
Fixes #200:

- Clean the content from links by moving them at the end for offline legibility
- Add some newlines to make some editor to convert the titles (Geany)
- Fix for some documentation and header titles