### PR TITLE
patch: improve distance still

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ very much welcome collaboration.
 
 ## News
 
-- 19 January 2020: Added Child Windows to develop (will merge to master in due time). [See Example](https://bit.ly/3iLMJt2).
+- 19 January 2021: Added Child Windows to develop (will merge to master in due time). [See Example](https://bit.ly/3iLMJt2).
 - 25 September 2020: Added [thumbwheels](https://github.com/cycfi/elements/issues/231).
 - 12 September 2020: Linux [Artist 2D Canvas Library](https://github.com/cycfi/artist)
   port feature complete.

--- a/examples/custom_control/main.cpp
+++ b/examples/custom_control/main.cpp
@@ -15,8 +15,8 @@ auto background = rbox(bkd_color, 5);
 // Function to calculate distance
 float distance(point a, point b)
 {
-  double c = (b.x - a.x) * (b.x - a.x) + (b.y - a.y) * (b.y - a.y);
-  return sqrt(c);
+  float c = (b.x - a.x) * (b.x - a.x) + (b.y - a.y) * (b.y - a.y);
+  return sqrtf(c);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/examples/custom_control/main.cpp
+++ b/examples/custom_control/main.cpp
@@ -15,7 +15,8 @@ auto background = rbox(bkd_color, 5);
 // Function to calculate distance
 float distance(point a, point b)
 {
-   return sqrt(pow(b.x - a.x, 2) +  pow(b.y - a.y, 2) * 1.0);
+  double c = (b.x - a.x) * (b.x - a.x) + (b.y - a.y) * (b.y - a.y);
+  return sqrt(c);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Unclear as to the exact reason this seems faster without a disassembly of sqrt or sqrtf.
It appears however to be removing two sse cast instructions. This is roughly upwards of 30x faster than the original, although it appears to dip below the previous commit on occasion?