### PR TITLE
Removed unnecessary license header in examples' CMake files

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#-
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
-
 add_subdirectory(empty)
 add_subdirectory(hello_universe)
 add_subdirectory(text_and_icons)
@@ -24,4 +18,3 @@ add_subdirectory(tooltip)
 add_subdirectory(dynamic_list)
 add_subdirectory(custom_control)
 add_subdirectory(child_window)
-

--- a/examples/basic_sliders_and_knobs/CMakeLists.txt
+++ b/examples/basic_sliders_and_knobs/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(BasicSlidersAndKnobs LANGUAGES C CXX)
 

--- a/examples/buttons/CMakeLists.txt
+++ b/examples/buttons/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Buttons LANGUAGES C CXX)
 

--- a/examples/child_window/CMakeLists.txt
+++ b/examples/child_window/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(EmptyStarter LANGUAGES C CXX)
 

--- a/examples/custom_control/CMakeLists.txt
+++ b/examples/custom_control/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(CustomControl LANGUAGES C CXX)
 

--- a/examples/dialogs/CMakeLists.txt
+++ b/examples/dialogs/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Dialogs LANGUAGES C CXX)
 

--- a/examples/doc_aspects/CMakeLists.txt
+++ b/examples/doc_aspects/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Aspects LANGUAGES C CXX)
 

--- a/examples/dynamic_list/CMakeLists.txt
+++ b/examples/dynamic_list/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(DynamicLists LANGUAGES C CXX VERSION "1.0.0")
 

--- a/examples/empty/CMakeLists.txt
+++ b/examples/empty/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(EmptyStarter LANGUAGES C CXX)
 

--- a/examples/hello_universe/CMakeLists.txt
+++ b/examples/hello_universe/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(HelloUniverse LANGUAGES C CXX)
 

--- a/examples/layout/CMakeLists.txt
+++ b/examples/layout/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Layout LANGUAGES C CXX)
 

--- a/examples/menus/CMakeLists.txt
+++ b/examples/menus/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Menus LANGUAGES C CXX)
 

--- a/examples/notebook/CMakeLists.txt
+++ b/examples/notebook/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Tabs LANGUAGES C CXX)
 

--- a/examples/popups/CMakeLists.txt
+++ b/examples/popups/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Popups LANGUAGES C CXX)
 

--- a/examples/scale/CMakeLists.txt
+++ b/examples/scale/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Scale LANGUAGES C CXX)
 

--- a/examples/simple_animation/CMakeLists.txt
+++ b/examples/simple_animation/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(HelloUniverse LANGUAGES C CXX)
 

--- a/examples/sprite_sliders_and_knobs/CMakeLists.txt
+++ b/examples/sprite_sliders_and_knobs/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(SpriteSlidersAndKnobs LANGUAGES C CXX)
 

--- a/examples/text_and_icons/CMakeLists.txt
+++ b/examples/text_and_icons/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(TextAndIcons LANGUAGES C CXX)
 

--- a/examples/text_edit/CMakeLists.txt
+++ b/examples/text_edit/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(TextEdit LANGUAGES C CXX)
 

--- a/examples/thumbwheels/CMakeLists.txt
+++ b/examples/thumbwheels/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Thumbwheels LANGUAGES C CXX VERSION "1.0.0")
 

--- a/examples/tooltip/CMakeLists.txt
+++ b/examples/tooltip/CMakeLists.txt
@@ -1,8 +1,3 @@
-###############################################################################
-#  Copyright (c) 2016-2020 Joel de Guzman
-#
-#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
-###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(Buttons LANGUAGES C CXX)
 


### PR DESCRIPTION
This to let people to use them as templates without mind the license.