### PR TITLE
Fix the maximum radius for canvas::round_rect

### DIFF
--- a/lib/src/support/canvas.cpp
+++ b/lib/src/support/canvas.cpp
@@ -218,7 +218,7 @@ namespace cycfi { namespace elements
       auto r = bounds.right;
       auto b = bounds.bottom;
       auto const a = M_PI/180.0;
-      radius = std::min(radius, std::min(bounds.width(), bounds.height()));
+      radius = std::min(radius, std::min(bounds.width(), bounds.height()) / 2);
 
       cairo_new_sub_path(&_context);
       cairo_arc(&_context, r-radius, y+radius, radius, -90*a, 0*a);


### PR DESCRIPTION
Hi, I recently came across your library and am thrilled to see a modern declarative UI library in C++. I have a fix for a small visual bug with rounded rectangles.

Prior to this change, using a radius that was too high would result in the arcs at the corners extending out too far and crossing one another:

![before](https://user-images.githubusercontent.com/47647589/141705564-b9597eef-8295-4415-b139-bf90d5012e54.png)

For perfectly rounded ends to a rectangle, the circumference of the circular arcs must be min(width, height). The radius should be half of that circumference. With the change applied the same rectangle now looks like this:

![after](https://user-images.githubusercontent.com/47647589/141705585-59e85a3c-8640-4bde-9fac-96589c01ae3c.png)

Here is the code for this minimal example:

```
#include <elements.hpp>

namespace elements = cycfi::elements;

int main(int argc, char * argv[])
{
    // standard setup
    auto app = elements::app { argc, argv, "radius_test", "radius_test" };
    auto window = elements::window { app.name() };
    window.on_close = [&app] { app.stop(); };
    auto view = elements::view { window };

    // white rbox with margins within a black background
    view.content(
        elements::layer(
            elements::margin(
                {50.0f, 50.0f, 50.0f, 50.0f},
                elements::rbox(elements::colors::white, 100000.0f) // extreme radius
            ),
            elements::box(elements::colors::black)
        )
    );

    app.run();
    return 0;
}
```