### PR TITLE
Icons list example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,5 +24,4 @@ add_subdirectory(tooltip)
 add_subdirectory(dynamic_list)
 add_subdirectory(custom_control)
 add_subdirectory(child_window)
-add_subdirectory(icons_list)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,4 +24,5 @@ add_subdirectory(tooltip)
 add_subdirectory(dynamic_list)
 add_subdirectory(custom_control)
 add_subdirectory(child_window)
+add_subdirectory(icons_list)
 

--- a/examples/icons_list/CMakeLists.txt
+++ b/examples/icons_list/CMakeLists.txt
@@ -1,0 +1,30 @@
+###############################################################################
+#  Copyright (c) 2016-2020 Joel de Guzman
+#
+#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
+###############################################################################
+cmake_minimum_required(VERSION 3.9.6...3.15.0)
+project(EmptyStarter LANGUAGES C CXX)
+
+if (NOT ELEMENTS_ROOT)
+   message(FATAL_ERROR "ELEMENTS_ROOT is not set")
+endif()
+
+# Make sure ELEMENTS_ROOT is an absolute path to add to the CMake module path
+get_filename_component(ELEMENTS_ROOT "${ELEMENTS_ROOT}" ABSOLUTE)
+set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ELEMENTS_ROOT}/cmake")
+
+# If we are building outside the project, you need to set ELEMENTS_ROOT:
+if (NOT ELEMENTS_BUILD_EXAMPLES)
+   include(ElementsConfigCommon)
+   set(ELEMENTS_BUILD_EXAMPLES OFF)
+   add_subdirectory(${ELEMENTS_ROOT} elements)
+endif()
+
+set(ELEMENTS_APP_PROJECT "ElementsIconsList")
+set(ELEMENTS_APP_TITLE "Elements Icons List")
+set(ELEMENTS_APP_COPYRIGHT "Copyright (c) 2021 Johann Philippe")
+set(ELEMENTS_APP_ID "com.johannphilippe.elements_icons_list")
+set(ELEMENTS_APP_VERSION "1.0")
+
+include(ElementsConfigApp)

--- a/examples/icons_list/CMakeLists.txt
+++ b/examples/icons_list/CMakeLists.txt
@@ -4,9 +4,7 @@
 #  Distributed under the MIT License (https://opensource.org/licenses/MIT)
 ###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
-project(EmptyStarter LANGUAGES C CXX)
-
-set(ELEMENTS_ROOT "/home/johann/Documents/GitHub/Forks/elements")
+project(ElementsIconsList LANGUAGES C CXX)
 
 if (NOT ELEMENTS_ROOT)
    message(FATAL_ERROR "ELEMENTS_ROOT is not set")

--- a/examples/icons_list/CMakeLists.txt
+++ b/examples/icons_list/CMakeLists.txt
@@ -6,6 +6,8 @@
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 project(EmptyStarter LANGUAGES C CXX)
 
+set(ELEMENTS_ROOT "/home/johann/Documents/GitHub/Forks/elements")
+
 if (NOT ELEMENTS_ROOT)
    message(FATAL_ERROR "ELEMENTS_ROOT is not set")
 endif()

--- a/examples/icons_list/README.md
+++ b/examples/icons_list/README.md
@@ -1,0 +1,16 @@
+# Notes 
+
+This example shows Elements icons next to their names. 
+
+# Add custom icons
+
+You can add custom to Elements icons using [Fontello](https://fontello.com/). 
+If you want to add custom icons to elements : 
+
+- Go to the resource/fonts directory. 
+- Drag/drop config.json file to fontello web page. 
+- You can then add any fontello icon to the icons list. 
+- Download the webfont.
+- In resource/fonts, replace elements_basic.ttf and config.json with the equivalents you just downloaded. 
+- If needed, you can use generate_enum.rb script to generate an C++ enum to use the icons. You can use it as follow : `ruby generate_enum.rb path/to/elements_basic_codes.css name_of_enum`. It will outprint the formatted enum with all icons from your font.
+

--- a/examples/icons_list/README.md
+++ b/examples/icons_list/README.md
@@ -12,5 +12,5 @@ If you want to add custom icons to elements :
 - You can then add any fontello icon to the icons list. 
 - Download the webfont.
 - In resource/fonts, replace elements_basic.ttf and config.json with the equivalents you just downloaded. 
-- If needed, you can use generate_enum.rb script to generate an C++ enum to use the icons. You can use it as follow : `ruby generate_enum.rb path/to/elements_basic_codes.css name_of_enum`. It will outprint the formatted enum with all icons from your font.
+- If needed, you can use generate_enum.rb script to generate an C++ enum to use the icons. You can use it as follow : `ruby generate_enum.rb path/to/elements_basic_codes.css name_of_enum`. It will print the formatted enum with all icons from your font.
 

--- a/examples/icons_list/generate_enum.rb
+++ b/examples/icons_list/generate_enum.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/ruby
+
+#First argument -> path to the css file containing the icon codes
+#Second argument (optional) -> name of the generated enum
+
+f= File.open(ARGV[0].to_s)
+str = f.read
+reg = /\.icon-([a-zA-Z0-9-]+):before\s{\scontent:\s'\\(e[0-9a-z]+)';/
+
+name = "custom_icons"
+if(ARGV.length > 1) then
+  namespace = ARGV[1]
+end
+
+fmt =  "enum class #{name} {\n"
+str.scan(reg) {|match|
+  fmt += "\t#{match[0]} = 0x#{match[1]}, \n"
+}
+fmt  += "}\n"
+puts fmt
+
+

--- a/examples/icons_list/main.cpp
+++ b/examples/icons_list/main.cpp
@@ -11,33 +11,31 @@ using namespace cycfi::elements;
 auto constexpr bkd_color = rgba(35, 35, 37, 255);
 auto background = box(bkd_color);
 
-class fixed_base : public default_label
+template<size_t Size>
+class fixed_size_base : public default_label
 {
 public:
     view_limits limits(const basic_context &ctx) const override
     {
-        // Give enough space for 4 characters
-        //(a track is not supposed to have more than 9999 lines, that would be huge)
-        point size = measure_text(ctx.canvas, "1234567890" ,get_font(), 16);
+
+        point size = measure_text(ctx.canvas, "9" ,get_font(), 16);
+        size.x *= Size;
         return { { size.x, size.y }, { size.x, size.y } };
     }
 };
 
-using basic_fixed = basic_label_base<fixed_base>;
-using fixed_label = label_gen<basic_fixed>;
+template<size_t Size>
+using basic_fixed_size = basic_label_base<fixed_size_base<Size>>;
+
+template<size_t Size>
+using fixed_size_label = label_gen<basic_fixed_size<Size>>;
 
 inline auto  make_icon_label(std::string name, int i)
 {
 
-    auto h = htile(fixed_label(name), hspacer(50), icon_button(i,1));
+    auto h = htile(fixed_size_label<10>(name), hspacer(50), icon_button(i,1));
     return share(h);
 }
-
-
-enum custom_icons
-{
-
-};
 
 int main(int argc, char* argv[])
 {

--- a/examples/icons_list/main.cpp
+++ b/examples/icons_list/main.cpp
@@ -1,0 +1,146 @@
+/*=============================================================================
+   Copyright (c) 2021 Johann Philippe
+
+   Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+#include <elements.hpp>
+
+using namespace cycfi::elements;
+
+// Main window background color
+auto constexpr bkd_color = rgba(35, 35, 37, 255);
+auto background = box(bkd_color);
+
+class fixed_base : public default_label
+{
+public:
+    view_limits limits(const basic_context &ctx) const override
+    {
+        // Give enough space for 4 characters
+        //(a track is not supposed to have more than 9999 lines, that would be huge)
+        point size = measure_text(ctx.canvas, "1234567890" ,get_font(), 16);
+        return { { size.x, size.y }, { size.x, size.y } };
+    }
+};
+
+using basic_fixed = basic_label_base<fixed_base>;
+using fixed_label = label_gen<basic_fixed>;
+
+inline auto  make_icon_label(std::string name, int i)
+{
+
+    auto h = htile(fixed_label(name), hspacer(50), icon_button(i,1));
+    return share(h);
+}
+
+
+enum custom_icons
+{
+
+};
+
+int main(int argc, char* argv[])
+{
+   app _app(argc, argv, "elements_icons_list", "com.johannphilippe.elements_icons_list");
+   window _win(_app.name());
+   _win.on_close = [&_app]() { _app.stop(); };
+
+   view view_(_win);
+
+   vtile_composite comp;
+   comp.push_back(make_icon_label("left", icons::left));
+   comp.push_back(make_icon_label("right", icons::right));
+   comp.push_back(make_icon_label("up", icons::up));
+   comp.push_back(make_icon_label("down", icons::down));
+   comp.push_back(make_icon_label("left_dir", icons::left_dir));
+   comp.push_back(make_icon_label("right_dir", icons::right_dir));
+   comp.push_back(make_icon_label("up_dir", icons::up_dir));
+   comp.push_back(make_icon_label("down_dir", icons::down_dir));
+   comp.push_back(make_icon_label("left_circled", icons::left_circled));
+   comp.push_back(make_icon_label("right_circled", icons::right_circled));
+   comp.push_back(make_icon_label("up_circled", icons::up_circled));
+   comp.push_back(make_icon_label("down_circled", icons::down_circled));
+   comp.push_back(make_icon_label("left_open", icons::left_open));
+   comp.push_back(make_icon_label("right_open", icons::right_open));
+   comp.push_back(make_icon_label("up_open", icons::up_open));
+   comp.push_back(make_icon_label("down_open", icons::down_open));
+   comp.push_back(make_icon_label("angle_left", icons::angle_left));
+   comp.push_back(make_icon_label("angle_right", icons::angle_right));
+   comp.push_back(make_icon_label("angle_up", icons::angle_up));
+   comp.push_back(make_icon_label("angle_down", icons::angle_down));
+   comp.push_back(make_icon_label("angle_double_left", icons::angle_double_left));
+   comp.push_back(make_icon_label("angle_double_right", icons::angle_double_right));
+   comp.push_back(make_icon_label("angle_double_up", icons::angle_double_up));
+   comp.push_back(make_icon_label("angle_double_down", icons::angle_double_down));
+   comp.push_back(make_icon_label("angle_circled_left", icons::angle_circled_left));
+   comp.push_back(make_icon_label("angle_circled_right", icons::angle_circled_right));
+   comp.push_back(make_icon_label("angle_circled_up", icons::angle_circled_up));
+   comp.push_back(make_icon_label("angle_circled_down", icons::angle_circled_down));
+   comp.push_back(make_icon_label("exclamation", icons::exclamation));
+   comp.push_back(make_icon_label("block", icons::block));
+   comp.push_back(make_icon_label("pencil", icons::pencil));
+   comp.push_back(make_icon_label("pin", icons::pin));
+   comp.push_back(make_icon_label("resize_vertical", icons::resize_vertical));
+   comp.push_back(make_icon_label("resize_horizontal", icons::resize_horizontal));
+   comp.push_back(make_icon_label("move", icons::move));
+   comp.push_back(make_icon_label("resize_full_alt", icons::resize_full_alt));
+   comp.push_back(make_icon_label("resize_full", icons::resize_full));
+   comp.push_back(make_icon_label("resize_small", icons::resize_small));
+   comp.push_back(make_icon_label("magnifying_glass", icons::magnifying_glass));
+   comp.push_back(make_icon_label("zoom_in", icons::zoom_in));
+   comp.push_back(make_icon_label("zoom_out", icons::zoom_out));
+   comp.push_back(make_icon_label("volume_off", icons::volume_off));
+   comp.push_back(make_icon_label("volume_down", icons::volume_down));
+   comp.push_back(make_icon_label("volume_up", icons::volume_up));
+   comp.push_back(make_icon_label("cw", icons::cw));
+   comp.push_back(make_icon_label("ccw", icons::ccw));
+   comp.push_back(make_icon_label("cycle", icons::cycle));
+   comp.push_back(make_icon_label("level_up", icons::level_up));
+   comp.push_back(make_icon_label("level_down", icons::level_down));
+   comp.push_back(make_icon_label("shuffle", icons::shuffle));
+   comp.push_back(make_icon_label("exchange", icons::exchange));
+   comp.push_back(make_icon_label("power", icons::power));
+   comp.push_back(make_icon_label("play", icons::play));
+   comp.push_back(make_icon_label("stop", icons::stop));
+   comp.push_back(make_icon_label("pause", icons::pause));
+   comp.push_back(make_icon_label("record", icons::record));
+   comp.push_back(make_icon_label("to_end", icons::to_end));
+   comp.push_back(make_icon_label("to_start", icons::to_start));
+   comp.push_back(make_icon_label("fast_forward", icons::fast_forward));
+   comp.push_back(make_icon_label("fast_backward", icons::fast_backward));
+   comp.push_back(make_icon_label("wrench", icons::wrench));
+   comp.push_back(make_icon_label("trash", icons::trash));
+   comp.push_back(make_icon_label("trash_empty", icons::trash_empty));
+   comp.push_back(make_icon_label("ok", icons::ok));
+   comp.push_back(make_icon_label("cancel", icons::cancel));
+   comp.push_back(make_icon_label("plus", icons::plus));
+   comp.push_back(make_icon_label("minus", icons::minus));
+   comp.push_back(make_icon_label("cog", icons::cog));
+   comp.push_back(make_icon_label("doc", icons::doc));
+   comp.push_back(make_icon_label("docs", icons::docs));
+   comp.push_back(make_icon_label("lock_open", icons::lock_open));
+   comp.push_back(make_icon_label("lock", icons::lock));
+   comp.push_back(make_icon_label("sliders", icons::sliders));
+   comp.push_back(make_icon_label("floppy", icons::floppy));
+   comp.push_back(make_icon_label("attention", icons::attention));
+   comp.push_back(make_icon_label("info", icons::info));
+   comp.push_back(make_icon_label("error", icons::error));
+   comp.push_back(make_icon_label("lightbulb", icons::lightbulb));
+   comp.push_back(make_icon_label("mixer", icons::mixer));
+   comp.push_back(make_icon_label("hand", icons::hand));
+   comp.push_back(make_icon_label("question", icons::question));
+   comp.push_back(make_icon_label("menu", icons::menu));
+   view_.content(
+               margin({10, 10, 10, 10},
+               vscroller(margin({40, 20, 40, 20}, comp))),
+                     // Add more content layers here. The order
+                     // specifies the layering. The lowest layer
+                     // is at the bottom of this list.
+
+      background     // Replace background with your main element,
+                     // or keep it and add another layer on top of it.
+   );
+
+   _app.run();
+   return 0;
+}


### PR DESCRIPTION
This example shows the full list of elements icons next to their names. 
It also contains information (README.md) on how to add custom icons with fontello, and a ruby script (generate_enum.rb) to generate c++ enum for custom icons. 
  