### PR TITLE
Active dynamic list

### DIFF
--- a/examples/active_dynamic_list/CMakeLists.txt
+++ b/examples/active_dynamic_list/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.9.6...3.15.0)
+project(ActiveDynamicList LANGUAGES C CXX)
+
+if (NOT ELEMENTS_ROOT)
+   message(FATAL_ERROR "ELEMENTS_ROOT is not set")
+endif()
+
+# Make sure ELEMENTS_ROOT is an absolute path to add to the CMake module path
+get_filename_component(ELEMENTS_ROOT "${ELEMENTS_ROOT}" ABSOLUTE)
+set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ELEMENTS_ROOT}/cmake")
+
+# If we are building outside the project, you need to set ELEMENTS_ROOT:
+if (NOT ELEMENTS_BUILD_EXAMPLES)
+   include(ElementsConfigCommon)
+   set(ELEMENTS_BUILD_EXAMPLES OFF)
+   add_subdirectory(${ELEMENTS_ROOT} elements)
+endif()
+
+set(ELEMENTS_APP_PROJECT "ActiveDynamicList")
+set(ELEMENTS_APP_TITLE "Active Dynamic List")
+set(ELEMENTS_APP_COPYRIGHT "Copyright (c) 2016-2020 Joel de Guzman")
+set(ELEMENTS_APP_ID "com.cycfi.active-dynamic-list")
+set(ELEMENTS_APP_VERSION "1.0")
+
+set(ELEMENTS_APP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+
+# For your custom application icon on macOS or Windows see cmake/AppIcon.cmake module
+include(AppIcon)
+include(ElementsConfigApp)

--- a/examples/active_dynamic_list/main.cpp
+++ b/examples/active_dynamic_list/main.cpp
@@ -1,0 +1,91 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+
+   Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+#include <elements.hpp>
+
+using namespace cycfi::elements;
+
+// Main window background color
+auto constexpr bkd_color = rgba(35, 35, 37, 255);
+auto background = box(bkd_color);
+
+class basic_row : public htile_composite
+{
+public:
+    basic_row(size_t index) : htile_composite(),
+        _index(index)
+    {
+        for(size_t i = 0; i < 4; i++)
+        {
+            auto input = input_box(std::to_string(index));
+            input.second->on_text = [&](std::string_view s ){
+                std::cout << "on text " << std::endl;
+            };
+            push_back(share(input.first));
+        }
+    }
+
+
+    size_t _index;
+};
+
+
+int main(int argc, char* argv[])
+{
+   app _app(argc, argv, "Active Dynamic List", "com.cycfi.active-dynamic-list");
+   window _win(_app.name());
+   _win.on_close = [&_app]() { _app.stop(); };
+
+   view view_(_win);
+
+    size_t list_size = 500;
+
+    std::vector<element_ptr> ptr_list;
+    ptr_list.resize(list_size, nullptr);
+    auto && make_row = [&](size_t index)
+    {
+        if(ptr_list[index].get() == nullptr)
+            ptr_list[index] = share(basic_row(index));
+        return ptr_list[index];
+    };
+
+   auto cp = basic_vertical_cell_composer(list_size, make_row);
+   auto content = vdynamic_list(cp);
+   auto linked = link(content);
+
+   auto b1 = icon_button(icons::minus, 1);
+   auto b2 = icon_button(icons::plus, 1);
+
+
+   b1.on_click = [&](bool) {
+       std::cout << "dn " << std::endl;
+       if(list_size <= 50) return;
+       list_size -= 50;
+       ptr_list.resize(list_size);
+       content.resize(list_size);
+       view_.refresh();
+   };
+   b2.on_click = [&](bool) {
+       std::cout << "up " << std::endl;
+       list_size +=50;
+       ptr_list.resize(list_size);
+       content.resize(list_size);
+       view_.refresh();
+   };
+
+
+   view_.content(
+               margin({10, 10, 10, 10},
+                      vtile(
+                          vscroller(hold(share(linked))),
+                          htile(b1, b2)
+                          )
+                      ),
+               background
+               );
+
+   _app.run();
+   return 0;
+}

--- a/examples/table_list/CMakeLists.txt
+++ b/examples/table_list/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.9.6...3.15.0)
+project(TableList LANGUAGES C CXX)
+
+if (NOT ELEMENTS_ROOT)
+   message(FATAL_ERROR "ELEMENTS_ROOT is not set")
+endif()
+
+# Make sure ELEMENTS_ROOT is an absolute path to add to the CMake module path
+get_filename_component(ELEMENTS_ROOT "${ELEMENTS_ROOT}" ABSOLUTE)
+set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ELEMENTS_ROOT}/cmake")
+
+# If we are building outside the project, you need to set ELEMENTS_ROOT:
+if (NOT ELEMENTS_BUILD_EXAMPLES)
+   include(ElementsConfigCommon)
+   set(ELEMENTS_BUILD_EXAMPLES OFF)
+   add_subdirectory(${ELEMENTS_ROOT} elements)
+endif()
+
+set(ELEMENTS_APP_PROJECT "TableList")
+set(ELEMENTS_APP_TITLE "Table List")
+set(ELEMENTS_APP_COPYRIGHT "Copyright (c) 2016-2020 Joel de Guzman")
+set(ELEMENTS_APP_ID "com.cycfi.table-list")
+set(ELEMENTS_APP_VERSION "1.0")
+
+set(ELEMENTS_APP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+
+# For your custom application icon on macOS or Windows see cmake/AppIcon.cmake module
+include(AppIcon)
+include(ElementsConfigApp)

--- a/examples/table_list/main.cpp
+++ b/examples/table_list/main.cpp
@@ -1,0 +1,106 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+
+   Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+#include <elements.hpp>
+
+using namespace cycfi::elements;
+
+// Main window background color
+auto constexpr bkd_color = rgba(35, 35, 37, 255);
+auto background = box(bkd_color);
+
+class table_cell_composer
+{
+public:
+    using composer_fn = std::function<element_ptr(size_t line, size_t index)>;
+    table_cell_composer(size_t lines, size_t columns, composer_fn &&fn)
+        : _num_lines(lines)
+        , _num_columns(columns)
+        , _composer(fn)
+    {}
+    element_ptr compose(size_t line, size_t col) {
+        return _composer(line, col);
+    }
+
+    size_t lines() {return _num_lines;}
+    size_t columns() {return _num_columns;}
+
+private:
+    size_t _num_lines, _num_columns;
+    composer_fn _composer;
+};
+
+class table_list : public vdynamic_list
+{
+public:
+    using table_composer_ptr = std::shared_ptr<table_cell_composer>;
+
+    element_ptr line_maker(size_t line)
+    {
+      if(h_list[line].get() == nullptr)
+      {
+          auto h_composer =
+                  basic_horizontal_cell_composer(_table_composer->columns(),
+                                                 [&, line](size_t col) {return _table_composer->compose(line, col);});
+          h_list[line] = share(hdynamic_list(h_composer));
+      }
+      return h_list[line];
+    };
+
+    table_list(table_composer_ptr ptr)
+        : vdynamic_list(basic_vertical_cell_composer(ptr->lines(), [&](size_t line) {return line_maker(line);})),
+          _table_composer(ptr),
+          h_list(ptr->lines(), nullptr)
+    {
+
+    }
+protected:
+    table_composer_ptr _table_composer;
+    std::vector<element_ptr> h_list;
+};
+
+int main(int argc, char* argv[])
+{
+   app _app(argc, argv, "Table List", "com.cycfi.table-list");
+   window _win(_app.name());
+   _win.on_close = [&_app]() { _app.stop(); };
+
+   view view_(_win);
+
+
+   size_t lines = 500;
+   size_t columns = 100;
+
+   std::vector<std::vector<element_ptr>> ptr_list(lines);
+   for(size_t i = 0; i < lines; i++)
+   {
+       ptr_list[i].resize(columns, nullptr);
+   }
+
+   auto && make_cell = [&](size_t l, size_t c)
+   {
+       color cell_color = ((l % 2 == 0) ? colors::red : colors::blue).opacity(c % 2 == 0 ? 1.0 : 0.5);
+       return share(limit({{100, 50}, {200, 100}},layer(
+                              label(std::string(std::to_string(l) + "  " + std::to_string(c))),
+                              rbox(cell_color, 6)
+                              )));
+   };
+
+   table_cell_composer comp(lines, columns, make_cell);
+   table_list l(share(comp));
+
+
+   view_.content(
+               margin({10, 10, 10, 10},
+                      scroller(
+                          hold(share(l))
+                          )
+                      ),
+               background
+               );
+
+   _app.run();
+   return 0;
+}	

--- a/lib/include/elements/element/dynamic_list.hpp
+++ b/lib/include/elements/element/dynamic_list.hpp
@@ -10,9 +10,12 @@
 #include <memory>
 #include <vector>
 #include <functional>
+#include<set>
+#include<iostream>
 
 namespace cycfi { namespace elements
 {
+
    ////////////////////////////////////////////////////////////////////////////
    // The cell composer abstract class
    ////////////////////////////////////////////////////////////////////////////
@@ -27,9 +30,10 @@ namespace cycfi { namespace elements
       };
 
       virtual std::size_t     size() const = 0;
+      virtual void			  resize(size_t s) = 0;
       virtual element_ptr     compose(std::size_t index) = 0;
-      virtual limits          width_limits(basic_context const& ctx) const = 0;
-      virtual float           line_height(std::size_t index, basic_context const& ctx) const = 0;
+      virtual limits		  secondary_axis_limits(basic_context const& ctx) const = 0;
+      virtual float			  main_axis_size(std::size_t index, basic_context const& ctx) const = 0;
    };
 
    ////////////////////////////////////////////////////////////////////////////
@@ -44,23 +48,22 @@ namespace cycfi { namespace elements
 
                               template <typename... Rest>
                               static_limits_cell_composer(
-                                 float min_width, float line_height
+                                 float min_secondary_axis_size, float main_axis_size
                                , Rest&& ...rest
                               );
 
                               template <typename... Rest>
                               static_limits_cell_composer(
-                                 float min_width, float max_width, float line_height
+                                 float min_secondary_axis_size, float max_secondary_axis_size, float main_axis_size
                                , Rest&& ...rest
                               );
-
-      cell_composer::limits   width_limits(basic_context const& ctx) const override;
-      float                   line_height(std::size_t index, basic_context const& ctx) const override;
+      cell_composer::limits		secondary_axis_limits(basic_context const& ctx) const override;
+      float 					main_axis_size(std::size_t index, basic_context const& ctx) const override;
 
    private:
 
-      float                   _line_height;
-       cell_composer::limits  _width_limits;
+      float 				  _main_axis_size;
+      cell_composer::limits	  _secondary_axis_limits;
    };
 
    ////////////////////////////////////////////////////////////////////////////
@@ -75,20 +78,34 @@ namespace cycfi { namespace elements
 
       using base_type = fixed_derived_limits_cell_composer<Base>;
 
-                              template <typename... Rest>
-                              fixed_derived_limits_cell_composer(Rest&& ...rest);
+                                template <typename... Rest>
+                                fixed_derived_limits_cell_composer(Rest&& ...rest);
 
-      cell_composer::limits   width_limits(basic_context const& ctx) const override;
-      float                   line_height(std::size_t index, basic_context const& ctx) const override;
+      cell_composer::limits		secondary_axis_limits(basic_context const& ctx) const override;
+      float 					main_axis_size(std::size_t index, basic_context const& ctx) const override;
 
-   private:
+   protected:
 
-      void                    get_limits(basic_context const& ctx) const;
+      virtual void              get_limits(basic_context const& ctx) const;
 
       using limits = cell_composer::limits;
 
-      mutable float           _line_height = -1;
-      mutable limits          _width_limits = { -1, full_extent };
+      mutable float 			_main_axis_size = -1;
+      mutable limits			_secondary_axis_limits = {-1, full_extent};
+   };
+
+   template<typename Base = cell_composer>
+   using vertical_fixed_derived_limits_cell_composer = fixed_derived_limits_cell_composer<Base>;
+
+   template<typename Base = cell_composer>
+   class horizontal_fixed_derived_limits_cell_composer: public fixed_derived_limits_cell_composer<Base>
+   {
+   public:
+      using base_type = horizontal_fixed_derived_limits_cell_composer<Base>;
+                                template <typename... Rest>
+                                horizontal_fixed_derived_limits_cell_composer(Rest&& ...rest);
+   protected:
+      virtual void              get_limits(basic_context const& ctx) const;
    };
 
    ////////////////////////////////////////////////////////////////////////////
@@ -108,7 +125,7 @@ namespace cycfi { namespace elements
                               {}
 
       std::size_t             size() const override { return _size; }
-
+      void 					  resize(size_t s) override {_size = s;}
    private:
 
       std::size_t             _size;
@@ -145,7 +162,26 @@ namespace cycfi { namespace elements
    {
       using ftype = remove_cvref_t<F>;
       using return_type =
-         fixed_derived_limits_cell_composer<
+         vertical_fixed_derived_limits_cell_composer<
+            fixed_length_cell_composer<
+               function_cell_composer<ftype>
+            >
+         >;
+      return share(return_type{ size, std::forward<ftype>(compose) });
+   }
+
+   template<typename F>
+   inline auto basic_vertical_cell_composer(std::size_t size, F&& compose)
+   {
+       return basic_cell_composer(size, compose);
+   }
+
+   template<typename F>
+   inline auto basic_horizontal_cell_composer(std::size_t size, F&& compose)
+   {
+      using ftype = remove_cvref_t<F>;
+      using return_type =
+         horizontal_fixed_derived_limits_cell_composer<
             fixed_length_cell_composer<
                function_cell_composer<ftype>
             >
@@ -159,7 +195,7 @@ namespace cycfi { namespace elements
    ////////////////////////////////////////////////////////////////////////////
    template <typename F>
    inline auto basic_cell_composer(
-      float min_width, float line_height, std::size_t size, F&& compose
+      float min_secondary_axis_size, float main_axis_size, std::size_t size, F&& compose
    )
    {
       using ftype = remove_cvref_t<F>;
@@ -171,8 +207,8 @@ namespace cycfi { namespace elements
          >;
       return share(
          return_type{
-            min_width
-          , line_height
+            min_secondary_axis_size
+          , main_axis_size
           , size
           , std::forward<ftype>(compose)
          }
@@ -185,7 +221,7 @@ namespace cycfi { namespace elements
    ////////////////////////////////////////////////////////////////////////////
    template <typename F>
    inline auto basic_cell_composer(
-      float min_width, float max_width, float line_height, std::size_t size, F&& compose
+      float min_secondary_axis_size, float max_secondary_axis_size, float main_axis_size, std::size_t size, F&& compose
    )
    {
       using ftype = remove_cvref_t<F>;
@@ -197,9 +233,9 @@ namespace cycfi { namespace elements
          >;
       return share(
          return_type{
-            min_width
-          , max_width
-          , line_height
+            min_secondary_axis_size
+          , max_secondary_axis_size
+          , main_axis_size
           , size
           , std::forward<ftype>(compose)
          }
@@ -207,7 +243,7 @@ namespace cycfi { namespace elements
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   // The main dynamic_list class
+   // The main dynamic_list class -> vertical by default
    ////////////////////////////////////////////////////////////////////////////
    class dynamic_list : public element
    {
@@ -219,34 +255,98 @@ namespace cycfi { namespace elements
                                   : _composer(composer)
                                  {}
 
-      view_limits                limits(basic_context const& ctx) const override;
+      virtual view_limits        limits(basic_context const& ctx) const override;
       void                       draw(context const& ctx) override;
       void                       layout(context const& ctx) override;
 
       void                       update();
       void                       update(basic_context const& ctx) const;
 
-   private:
+      virtual bool 				 click(const context &ctx, mouse_button btn) override;
+      virtual bool 				 text(context const& ctx, text_info info) override;
+      virtual bool 				 key(const context &ctx, key_info k) override;
+      virtual bool 				 cursor(context const& ctx, point p, cursor_tracking status) override;
+      virtual bool 				 scroll(context const& ctx, point dir, point p) override;
+      virtual void 		    	 drag(context const& ctx, mouse_button btn) override;
 
-      struct row_info
+      void 			   			 new_focus(context const& ctx, int index);
+      bool 				   		 wants_control() const override;
+      bool                       wants_focus() const override;
+      void                    	 begin_focus() override;
+      void                    	 end_focus() override;
+      element const*          	 focus() const override;
+      element*                	 focus() override;
+      void                    	 focus(std::size_t index);
+      virtual void            	 reset();
+      void 						 resize(size_t n);
+
+       struct hit_info
+       {
+          element_ptr            element;
+          rect                   bounds   = rect{};
+          int                    index    = -1;
+       };
+
+      virtual rect 				 bounds_of(context const& ctx, int ix) const;
+      virtual bool 			 	 reverse_index() const {return false;}
+      virtual hit_info 			 hit_element(context const& ctx, point p, bool control) const;
+
+   protected:
+      struct cell_info
       {
          double                  pos;
-         double                  height;
+         double                  main_axis_size;
          element_ptr             elem_ptr;
          int                     layout_id = -1;
       };
 
-      using rows_vector = std::vector<row_info>;
+      // virtual methods to specialize in hdynamic or vdynamic
+      virtual view_limits 		 make_limits(float main_axis_size, cell_composer::limits secondary_axis_limits ) const;
+      virtual float 	  		 get_main_axis_start(const rect &r);
+      virtual float 	  	     get_main_axis_end(const rect &r);
+      virtual void 	  			 make_bounds(context& ctx, float main_axis_start, cell_info &info);
+
+      using cells_vector = std::vector<cell_info>;
+      mutable cells_vector        _cells;
+
+   private:
 
       composer_ptr               _composer;
       point                      _previous_size;
       std::size_t                _previous_window_start = 0;
       std::size_t                _previous_window_end = 0;
 
-      mutable rows_vector        _rows;
-      mutable double             _height = 0;
+      mutable double 			 _main_axis_full_size = 0;
       mutable int                _layout_id = 0;
       mutable bool               _update_request = true;
+
+      int 					   	 _focus = -1;
+      int 					     _saved_focus = -1;
+      int                        _click_tracking = -1;
+      int                        _cursor_tracking = -1;
+      std::set<int>           	 _cursor_hovering;
+   };
+
+   ////////////////////////////////////////////////////////////////////////////
+   // The vertical dynamic_list class - just an alias
+   ////////////////////////////////////////////////////////////////////////////
+   using vdynamic_list = dynamic_list;
+
+   ////////////////////////////////////////////////////////////////////////////
+   // The horizontal dynamic_list class
+   ////////////////////////////////////////////////////////////////////////////
+   class hdynamic_list : public dynamic_list
+   {
+   public:
+                                 hdynamic_list(composer_ptr ptr) : dynamic_list(ptr) {}
+      rect 						 bounds_of(context const& ctx, int ix) const override;
+
+   protected:
+      view_limits 				 make_limits(float main_axis_size, cell_composer::limits secondary_axis_limits) const override;
+      void 						 make_bounds(context &ctx, float main_axis_start, cell_info &info) override;
+      float 					 get_main_axis_start(const rect&r) override;
+      float 					 get_main_axis_end(const rect &r) override;
+
    };
 
    ////////////////////////////////////////////////////////////////////////////
@@ -255,39 +355,39 @@ namespace cycfi { namespace elements
    template <typename Base>
    template <typename... Rest>
    inline static_limits_cell_composer<Base>::static_limits_cell_composer(
-      float min_width
-    , float line_height
+      float min_secondary_axis_size
+    , float main_axis_size
     , Rest&& ...rest
    )
     : Base(std::forward<Rest>(rest)...)
-    , _line_height{ line_height }
-    , _width_limits{ min_width, full_extent }
+    , _main_axis_size{ main_axis_size }
+    , _secondary_axis_limits{ min_secondary_axis_size, full_extent }
    {}
 
    template <typename Base>
    template <typename... Rest>
    inline static_limits_cell_composer<Base>::static_limits_cell_composer(
-      float min_width
-    , float max_width
-    , float line_height
+      float min_secondary_axis_size
+    , float max_secondary_axis_size
+    , float main_axis_size
     , Rest&& ...rest
    )
     : Base(std::forward<Rest>(rest)...)
-    , _line_height(line_height)
-    , _width_limits{ min_width, max_width }
+    , _main_axis_size(main_axis_size)
+    , _secondary_axis_limits{ min_secondary_axis_size, max_secondary_axis_size }
    {}
 
    template <typename Base>
    inline cell_composer::limits
-   static_limits_cell_composer<Base>::width_limits(basic_context const& /*ctx*/) const
+   static_limits_cell_composer<Base>::secondary_axis_limits(basic_context const& /*ctx*/) const
    {
-      return _width_limits;
+      return _secondary_axis_limits;
    }
 
    template <typename Base>
-   inline float static_limits_cell_composer<Base>::line_height(std::size_t /*index*/, basic_context const& /*ctx*/) const
+   inline float static_limits_cell_composer<Base>::main_axis_size(std::size_t /*index*/, basic_context const& /*ctx*/) const
    {
-      return _line_height;
+      return _main_axis_size;
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -297,34 +397,51 @@ namespace cycfi { namespace elements
       Rest&& ...rest
    )
     : Base(std::forward<Rest>(rest)...)
-    , _line_height{ -1 }
-    , _width_limits{ -1, full_extent }
+    , _main_axis_size{ -1 }
+    , _secondary_axis_limits{ -1, full_extent }
    {}
 
    template <typename Base>
    inline cell_composer::limits
-   fixed_derived_limits_cell_composer<Base>::width_limits(basic_context const& ctx) const
+   fixed_derived_limits_cell_composer<Base>::secondary_axis_limits(basic_context const& ctx) const
    {
-      if (_width_limits.min == -1)
+      if (_secondary_axis_limits.min == -1)
          get_limits(ctx);
-      return _width_limits;
+      return _secondary_axis_limits;
    }
 
    template <typename Base>
-   inline float fixed_derived_limits_cell_composer<Base>::line_height(std::size_t /*index*/, basic_context const& ctx) const
+   inline float fixed_derived_limits_cell_composer<Base>::main_axis_size(std::size_t /*index*/, basic_context const& ctx) const
    {
-      if (_line_height == -1)
+      if (_main_axis_size == -1)
          get_limits(ctx);
-      return _line_height;
+      return _main_axis_size;
    }
 
    template <typename Base>
    void fixed_derived_limits_cell_composer<Base>::get_limits(basic_context const& ctx) const
    {
       auto lim = const_cast<base_type*>(this)->compose(0)->limits(ctx);
-      _width_limits.min = lim.min.x;
-      _width_limits.max = lim.max.x;
-      _line_height = lim.min.y;
+      _secondary_axis_limits.min = lim.min.x;
+      _secondary_axis_limits.max = lim.max.x;
+      _main_axis_size = lim.min.y;
+   }
+
+   template <typename Base>
+   template <typename... Rest>
+   inline horizontal_fixed_derived_limits_cell_composer<Base>::horizontal_fixed_derived_limits_cell_composer(
+      Rest&& ...rest
+   )
+    : fixed_derived_limits_cell_composer<Base> (std::forward<Rest>(rest)...)
+   {}
+
+   template<typename Base>
+   void horizontal_fixed_derived_limits_cell_composer<Base>::get_limits(basic_context const& ctx)  const
+   {
+      auto lim = const_cast<base_type*>(this)->compose(0)->limits(ctx);
+      this->_secondary_axis_limits.min = lim.min.y;
+      this->_secondary_axis_limits.max = lim.max.y;
+      this->_main_axis_size = lim.min.x;
    }
 }}
 

--- a/lib/src/element/dynamic_list.cpp
+++ b/lib/src/element/dynamic_list.cpp
@@ -13,14 +13,13 @@ namespace cycfi { namespace elements
       if (_composer)
       {
          if (_update_request)
+         {
             update(ctx);
-         auto w_limits = _composer->width_limits(ctx);
+         }
+         auto secondary_limits = _composer->secondary_axis_limits(ctx);
          if (_composer->size())
          {
-            return {
-               { w_limits.min, float(_height) }
-             , { w_limits.max, float(_height) }
-            };
+            return make_limits(float(_main_axis_full_size),  secondary_limits);
          }
       }
       return {{ 0, 0 }, { 0, 0 }};
@@ -28,49 +27,54 @@ namespace cycfi { namespace elements
 
    void dynamic_list::draw(context const& ctx)
    {
+       // Johann Philippe : this seems to be necessary for context where a hdynamic_list is inside vdynamic_list (2D tables)
+      if (_update_request)
+           update(ctx);
+
       auto& cnv = ctx.canvas;
       auto  state = cnv.new_state();
       auto  clip_extent = cnv.clip_extent();
-      auto  top = ctx.bounds.top;
+      auto main_axis_start = get_main_axis_start(ctx.bounds);
 
       if (!intersects(ctx.bounds, clip_extent))
          return;
 
-      auto it = std::lower_bound(_rows.begin(), _rows.end(),
-         clip_extent.top-top,
-         [](auto const& row, double pivot)
+      auto it = std::lower_bound(_cells.begin(), _cells.end(),
+         get_main_axis_start(clip_extent) - main_axis_start,
+         [](auto const& cell, double pivot)
          {
-            return (row.pos + row.height) < pivot;
+            return (cell.pos + cell.main_axis_size) < pivot;
          }
       );
 
       // Draw the rows within the visible bounds of the view
-      std::size_t new_start = it - _rows.begin();
-      for (; it != _rows.end(); ++it)
+      std::size_t new_start = it - _cells.begin();
+
+      for (; it != _cells.end(); ++it)
       {
-         auto& row = *it;
-         context rctx { ctx, row.elem_ptr.get(), ctx.bounds };
-         rctx.bounds.top = top + row.pos;
-         rctx.bounds.height(row.height);
+         auto& cell = *it;
+         context rctx { ctx, cell.elem_ptr.get(), ctx.bounds };
+         make_bounds(rctx, main_axis_start, cell);
          if (intersects(clip_extent, rctx.bounds))
          {
-            if (!row.elem_ptr)
+            if (!cell.elem_ptr)
             {
-               row.elem_ptr = _composer->compose(it-_rows.begin());
-               row.elem_ptr->layout(rctx);
-               row.layout_id = _layout_id;
+               cell.elem_ptr = _composer->compose(it-_cells.begin());
+               cell.elem_ptr->layout(rctx);
+               cell.layout_id = _layout_id;
             }
-            else if (row.layout_id != _layout_id)
+            else if (cell.layout_id != _layout_id)
             {
-               row.elem_ptr->layout(rctx);
-               row.layout_id = _layout_id;
+               cell.elem_ptr->layout(rctx);
+               cell.layout_id = _layout_id;
             }
-            row.elem_ptr->draw(rctx);
+            cell.elem_ptr->draw(rctx);
          }
-         if (rctx.bounds.top > clip_extent.bottom)
-            break;
+
+         if(get_main_axis_start(rctx.bounds) > get_main_axis_end(clip_extent))
+             break;
       }
-      std::size_t new_end = it - _rows.begin();
+      std::size_t new_end = it - _cells.begin();
 
       // Cleanup old rows
       if (new_start != _previous_window_start || new_end != _previous_window_end)
@@ -79,8 +83,7 @@ namespace cycfi { namespace elements
          {
             if (i < new_start || i >= new_end)
             {
-               _rows[i].elem_ptr.reset();
-               _rows[i].layout_id = -1;
+               _cells[i].layout_id = -1;
             }
          }
       }
@@ -105,8 +108,8 @@ namespace cycfi { namespace elements
    void dynamic_list::update()
    {
       _update_request = true;
-      _rows.clear();
-      _height = 0;
+      _cells.clear();
+      _main_axis_full_size = 0;
    }
 
    void dynamic_list::update(basic_context const& ctx) const
@@ -116,18 +119,436 @@ namespace cycfi { namespace elements
          if (auto size = _composer->size())
          {
             double y = 0;
-            _rows.reserve(_composer->size());
+            _cells.reserve(_composer->size());
             for (std::size_t i = 0; i != size; ++i)
             {
-               auto line_height = _composer->line_height(i, ctx);
-               _rows.push_back({ y, line_height, nullptr });
-               y += line_height;
+               auto main_axis_size = _composer->main_axis_size(i, ctx);
+               _cells.push_back({ y, main_axis_size, nullptr });
+               y += main_axis_size;
             }
-            _height = y;
+            _main_axis_full_size = y;
          }
       }
       ++_layout_id;
       _update_request = false;
    }
+
+
+   bool dynamic_list::click(const context &ctx, mouse_button btn)
+   {
+       if (!_cells.empty())
+       {
+          if (btn.down) // button down
+          {
+             hit_info info = hit_element(ctx, btn.pos, true);
+             if (info.element)
+             {
+                if (wants_focus() && _focus != info.index)
+                   new_focus(ctx, info.index);
+
+                context ectx{ ctx, info.element.get(), info.bounds };
+                if (info.element->click(ectx, btn))
+                {
+                   if (btn.down)
+                      _click_tracking = info.index;
+                   return true;
+                }
+             }
+          }
+          else if (_click_tracking != -1) // button up
+          {
+             rect  bounds = bounds_of(ctx, _click_tracking);
+             auto& e = *_composer->compose(_click_tracking);
+             context ectx{ ctx, &e, bounds };
+             if (e.click(ectx, btn))
+             {
+                return true;
+             }
+          }
+       }
+       _click_tracking = -1;
+       return false;
+   }
+
+   bool dynamic_list::text(context const& ctx, text_info info)
+   {
+      if (_focus != -1)
+      {
+         rect  bounds = bounds_of(ctx, _focus);
+         auto& focus_ = *_cells[_focus].elem_ptr;
+         context ectx{ ctx, &focus_, bounds };
+         return focus_.text(ectx, info);
+      };
+      return false;
+   }
+
+   void dynamic_list::new_focus(context const& ctx, int index)
+   {
+       if (_focus != -1 )
+       {
+           _composer->compose(_focus)->end_focus();
+           ctx.view.refresh(ctx);
+       }
+
+       // start a new focus
+       _focus = index;
+       if (_focus != -1 && _cells[_focus].elem_ptr != nullptr)
+
+       {
+           _cells[_focus].elem_ptr->begin_focus();
+           ctx.view.refresh(ctx);
+       }
+   }
+
+
+   bool dynamic_list::key(const context &ctx, key_info k)
+   {
+       auto&& try_key = [&](int ix) -> bool
+       {
+           rect bounds = bounds_of(ctx, ix);
+           auto& e = *_composer->compose(ix).get();
+           context ectx{ ctx, &e, bounds };
+           bool b = e.key(ectx, k);
+           return b;
+       };
+
+
+       auto&& try_focus = [&](int ix) -> bool
+       {
+           if (_composer->compose(ix)->wants_focus())
+           {
+               new_focus(ctx, ix);
+               return true;
+           }
+           return false;
+       };
+
+       if (_focus != -1)
+       {
+           // when tab is pressed at the end of the scroller, it doesn't automatically scroll
+           if (try_key(_focus))
+               return true;
+       }
+
+
+       if ((k.action == key_action::press || k.action == key_action::repeat)
+               && k.key == key_code::tab && _cells.size())
+       {
+           int next_focus = _focus;
+           bool reverse = (k.modifiers & mod_shift) ^ reverse_index();
+
+           if( (next_focus == -1)  || !reverse)
+           {
+               while (++next_focus != static_cast<int>(_cells.size()))
+               {
+                   if (try_focus(next_focus))
+                       return true;
+               }
+               return false;
+           }
+           else
+           {
+               while (--next_focus >= 0)
+               {
+                   if (_composer->compose(next_focus)->wants_focus())
+                       if (try_focus(next_focus))
+                           return true;
+               }
+               return false;
+           }
+       }
+       // Johann Philippe : The following code comes from composite_base.
+       // I commented that since it caused crashes. Still don't know if that can be useful to adapt.
+
+       // If we reached here, then there's either no focus, or the
+       // focus did not handle the key press.
+
+       /*
+       if (reverse_index())
+       {
+          for (int ix = int(_cells.size())-1; ix >= 0; --ix)
+          {
+             if (try_key(ix))
+                return true;
+          }
+       }
+       else
+       {
+          for (std::size_t ix = 0; ix < _cells.size(); ++ix)
+          {
+             if (try_key(ix))
+                return true;
+          }
+       }
+       */
+       return false;
+   }
+
+   bool dynamic_list::cursor(const context &ctx, point p, cursor_tracking status)
+   {
+
+      if (_cursor_tracking >= int(_cells.size())) // just to be sure!
+         _cursor_tracking = -1;
+
+      // Send cursor leaving to all currently hovering elements if cursor is
+      // leaving the composite.
+      if (status == cursor_tracking::leaving)
+      {
+         for (auto ix : _cursor_hovering)
+         {
+            if (ix < int(_cells.size()))
+            {
+               auto& e = *_composer->compose(ix).get();
+               context ectx{ ctx, &e, bounds_of(ctx, ix) };
+               e.cursor(ectx, p, cursor_tracking::leaving);
+            }
+         }
+         return false;
+      }
+
+      // Send cursor leaving to all currently hovering elements if p is
+      // outside the elements's bounds or if the element is no longer hit.
+      for (auto i = _cursor_hovering.begin(); i != _cursor_hovering.end();)
+      {
+         if (*i < int(_cells.size()))
+         {
+            auto& e = *_composer->compose(*i).get();
+            rect  b = bounds_of(ctx, *i);
+            context ectx{ ctx, &e, b };
+            if (!b.includes(p) || !e.hit_test(ectx, p))
+            {
+               e.cursor(ectx, p, cursor_tracking::leaving);
+               i = _cursor_hovering.erase(i);
+               continue;
+            }
+         }
+         ++i;
+      }
+
+      // Send cursor entering to newly hit element or hovering to current
+      // tracking element
+      hit_info info = hit_element(ctx, p, true);
+      if (info.element)
+      {
+         _cursor_tracking = info.index;
+         status = cursor_tracking::hovering;
+         if (_cursor_hovering.find(info.index) == _cursor_hovering.end())
+         {
+             status = cursor_tracking::entering;
+            _cursor_hovering.insert(_cursor_tracking);
+         }
+         auto& e = *_composer->compose(_cursor_tracking).get();
+         context ectx{ ctx, &e, bounds_of(ctx, _cursor_tracking) };
+         return e.cursor(ectx, p, status);
+      }
+
+      return false;
+   }
+
+   void dynamic_list::drag(const context &ctx, mouse_button btn)
+   {
+       if (_click_tracking != -1)
+       {
+          rect  bounds = bounds_of(ctx, _click_tracking);
+          auto& e = *_composer->compose(_click_tracking).get();
+          context ectx{ ctx, &e, bounds };
+          e.drag(ectx, btn);
+       }
+   }
+
+
+   bool dynamic_list::scroll(context const& ctx, point dir, point p)
+   {
+      if (!_cells.empty())
+      {
+         hit_info info = hit_element(ctx, p, true);
+         if (auto ptr = info.element; ptr && elements::intersects(info.bounds, ctx.view_bounds()))
+         {
+            context ectx{ ctx, ptr.get(), info.bounds };
+            return ptr->scroll(ectx, dir, p);
+         }
+      }
+      return false;
+   }
+
+
+   bool dynamic_list::wants_focus() const
+   {
+       for (std::size_t ix = 0; ix != _cells.size(); ++ix)
+           if (_cells[ix].elem_ptr != nullptr && _cells[ix].elem_ptr->wants_focus())
+               return true;
+       return false;
+   }
+
+   bool dynamic_list::wants_control() const
+   {
+      for (std::size_t ix = 0; ix < _cells.size(); ++ix)
+         if (_cells[ix].elem_ptr != nullptr && _cells[ix].elem_ptr->wants_control())
+            return true;
+      return false;
+   }
+
+   void dynamic_list::begin_focus()
+   {
+       if (_focus == -1)
+           _focus = _saved_focus;
+       if (_focus == -1)
+       {
+           for (std::size_t ix = 0; ix != _cells.size(); ++ix)
+               if (_cells[ix].elem_ptr != nullptr && _cells[ix].elem_ptr->wants_focus())
+               {
+                   _focus = ix;
+                   break;
+               }
+       }
+       if (_focus != -1 && _cells[_focus].elem_ptr != nullptr)
+           _cells[_focus].elem_ptr->begin_focus();
+   }
+
+
+   void dynamic_list::end_focus()
+   {
+       if (_focus != -1 && _cells[_focus].elem_ptr != nullptr)
+           _cells[_focus].elem_ptr->end_focus();
+       _saved_focus = _focus;
+       _focus = -1;
+   }
+
+
+   element const* dynamic_list::focus() const
+   {
+       return (_cells.empty() || (_focus == -1))? 0 : _cells[_focus].elem_ptr.get();
+   }
+
+
+   element* dynamic_list::focus()
+   {
+       return (_cells.empty() || (_focus == -1))? 0 : _cells[_focus].elem_ptr.get();
+   }
+
+
+   void dynamic_list::focus(std::size_t index)
+   {
+       if (index < _cells.size())
+           _focus = int(index);
+   }
+
+
+   void dynamic_list::reset()
+   {
+       _focus = -1;
+       _saved_focus = -1;
+       _click_tracking = -1;
+       _cursor_tracking = -1;
+       _cursor_hovering.clear();
+   }
+
+   void dynamic_list::resize(size_t n)
+   {
+       this->_composer->resize(n);
+       this->update();
+   }
+
+   dynamic_list::hit_info dynamic_list::hit_element(context const& ctx, point p, bool control) const
+   {
+      auto&& test_element =
+         [&](int ix, hit_info& info) -> bool
+         {
+            if(_cells[ix].elem_ptr == nullptr) {return false;}
+            auto& e = *_cells[ix].elem_ptr;
+            if (!control || e.wants_control())
+            {
+               rect bounds = bounds_of(ctx, ix);
+               if (bounds.includes(p))
+               {
+                  context ectx{ ctx, &e, bounds };
+                  if (e.hit_test(ectx, p))
+                  {
+                     info = hit_info{ e.shared_from_this(), bounds, int(ix) };
+                     return true;
+                  }
+               }
+            }
+            return false;
+         };
+
+      hit_info info = hit_info{ {}, rect{}, -1 };
+      if (reverse_index())
+      {
+         for (int ix = int(_cells.size())-1; ix >= 0; --ix)
+            if (test_element(ix, info))
+               break;
+      }
+      else
+      {
+         for (std::size_t ix = 0; ix < _cells.size(); ++ix)
+            if (test_element(ix, info))
+               break;
+      }
+      return info;
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
+   // Vertical dynamic_list methods
+   ////////////////////////////////////////////////////////////////////////////
+   float dynamic_list::get_main_axis_start(const rect &r)
+   {return r.top;}
+
+   float dynamic_list::get_main_axis_end(const rect &r)
+   {return r.bottom;}
+
+   view_limits dynamic_list::make_limits(float main_axis_size, cell_composer::limits secondary_axis_limits) const
+   {
+       return {
+          { secondary_axis_limits.min, float(main_axis_size) }
+        , { secondary_axis_limits.max, float(main_axis_size) } };
+   }
+
+   void dynamic_list::make_bounds(context &ctx, float main_axis_pos, cell_info &cell)
+   {
+       ctx.bounds.top = main_axis_pos + cell.pos;
+       ctx.bounds.height(cell.main_axis_size);
+   }
+
+   rect dynamic_list::bounds_of(context const& ctx, int ix) const
+   {
+       rect r = ctx.bounds;
+       r.top = ctx.bounds.top + _cells[ix].pos;
+       r.height(_cells[ix].main_axis_size);
+       return r;
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
+   // Horizontal dynamic_list methods
+   ////////////////////////////////////////////////////////////////////////////
+
+   float hdynamic_list::get_main_axis_start(const rect &r)
+   {return r.left;}
+
+   float hdynamic_list::get_main_axis_end(const rect &r)
+   {return r.right;}
+
+   view_limits hdynamic_list::make_limits(float main_axis_size, cell_composer::limits secondary_axis_limits) const
+   {
+       return {
+          { main_axis_size, secondary_axis_limits.min }
+        , { main_axis_size, secondary_axis_limits.max } };
+   }
+
+   void hdynamic_list::make_bounds(context &ctx, float main_axis_pos, cell_info &cell)
+   {
+       ctx.bounds.left = main_axis_pos + cell.pos;
+       ctx.bounds.width(cell.main_axis_size);
+   }
+
+   rect hdynamic_list::bounds_of(context const& ctx, int ix) const
+   {
+       rect r = ctx.bounds;
+       r.left = ctx.bounds.left + _cells[ix].pos;
+       r.width(_cells[ix].main_axis_size);
+       return r;
+   }
+
 }}
+
 

--- a/lib/src/support/canvas.cpp
+++ b/lib/src/support/canvas.cpp
@@ -218,7 +218,7 @@ namespace cycfi { namespace elements
       auto r = bounds.right;
       auto b = bounds.bottom;
       auto const a = M_PI/180.0;
-      radius = std::min(radius, std::min(bounds.width(), bounds.height()));
+      radius = std::min(radius, std::min(bounds.width(), bounds.height()) / 2);
 
       cairo_new_sub_path(&_context);
       cairo_arc(&_context, r-radius, y+radius, radius, -90*a, 0*a);


### PR DESCRIPTION
List of the improvements for dynamic list : 
* Elements inside the list can now be active controls (it is recommanded that the user keeps pointers to created elements) and respond to clicks, keys, drag, scroll, cursor (...)
* Allows vertical and horizontal list `vdynamic_list` and `hdynamic_list`
* Composers are adapted as well `basic_vertical_cell_composer` and `basic_horizontal_cell_composer`
* `resize` method to dynamically resize the list 

What does not work : 
* making a vdynamic_list containing hdynamic_lists works a little bit. There are some errors in static context (inactive elements) and with active elements. In static contexts there seem to be some drawing issues (it draws fine, but not with proper data it seems). And with active elements, the user actions do not seem to propagate to the right widgets.  See `two_dimensional_list` example. 