### PR TITLE
On scroll callback and set_position for scrollbars

### DIFF
--- a/examples/sync_scrollbars/CMakeLists.txt
+++ b/examples/sync_scrollbars/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 set(ELEMENTS_APP_PROJECT "SyncScrollbars")
 set(ELEMENTS_APP_TITLE "Sync Scrollbars")
 set(ELEMENTS_APP_COPYRIGHT "Copyright (c) 2016-2020 Joel de Guzman")
-set(ELEMENTS_APP_ID "com.cycfi.empty-starter")
+set(ELEMENTS_APP_ID "com.cycfi.sync-scrollbars")
 set(ELEMENTS_APP_VERSION "1.0")
 
 set(ELEMENTS_APP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)

--- a/examples/sync_scrollbars/CMakeLists.txt
+++ b/examples/sync_scrollbars/CMakeLists.txt
@@ -4,9 +4,7 @@
 #  Distributed under the MIT License (https://opensource.org/licenses/MIT)
 ###############################################################################
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
-project(EmptyStarter LANGUAGES C CXX)
-
-set(ELEMENTS_ROOT "/home/johann/Documents/Elements/elements")
+project(SyncScrollbars LANGUAGES C CXX)
 
 if (NOT ELEMENTS_ROOT)
    message(FATAL_ERROR "ELEMENTS_ROOT is not set")
@@ -23,10 +21,12 @@ if (NOT ELEMENTS_BUILD_EXAMPLES)
    add_subdirectory(${ELEMENTS_ROOT} elements)
 endif()
 
-set(ELEMENTS_APP_PROJECT "EmptyStarter")
-set(ELEMENTS_APP_TITLE "Empty Starter")
+set(ELEMENTS_APP_PROJECT "SyncScrollbars")
+set(ELEMENTS_APP_TITLE "Sync Scrollbars")
 set(ELEMENTS_APP_COPYRIGHT "Copyright (c) 2016-2020 Joel de Guzman")
 set(ELEMENTS_APP_ID "com.cycfi.empty-starter")
 set(ELEMENTS_APP_VERSION "1.0")
+
+set(ELEMENTS_APP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
 include(ElementsConfigApp)

--- a/examples/sync_scrollbars/CMakeLists.txt
+++ b/examples/sync_scrollbars/CMakeLists.txt
@@ -1,0 +1,32 @@
+###############################################################################
+#  Copyright (c) 2016-2020 Joel de Guzman
+#
+#  Distributed under the MIT License (https://opensource.org/licenses/MIT)
+###############################################################################
+cmake_minimum_required(VERSION 3.9.6...3.15.0)
+project(EmptyStarter LANGUAGES C CXX)
+
+set(ELEMENTS_ROOT "/home/johann/Documents/Elements/elements")
+
+if (NOT ELEMENTS_ROOT)
+   message(FATAL_ERROR "ELEMENTS_ROOT is not set")
+endif()
+
+# Make sure ELEMENTS_ROOT is an absolute path to add to the CMake module path
+get_filename_component(ELEMENTS_ROOT "${ELEMENTS_ROOT}" ABSOLUTE)
+set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ELEMENTS_ROOT}/cmake")
+
+# If we are building outside the project, you need to set ELEMENTS_ROOT:
+if (NOT ELEMENTS_BUILD_EXAMPLES)
+   include(ElementsConfigCommon)
+   set(ELEMENTS_BUILD_EXAMPLES OFF)
+   add_subdirectory(${ELEMENTS_ROOT} elements)
+endif()
+
+set(ELEMENTS_APP_PROJECT "EmptyStarter")
+set(ELEMENTS_APP_TITLE "Empty Starter")
+set(ELEMENTS_APP_COPYRIGHT "Copyright (c) 2016-2020 Joel de Guzman")
+set(ELEMENTS_APP_ID "com.cycfi.empty-starter")
+set(ELEMENTS_APP_VERSION "1.0")
+
+include(ElementsConfigApp)

--- a/examples/sync_scrollbars/main.cpp
+++ b/examples/sync_scrollbars/main.cpp
@@ -6,7 +6,6 @@
 #include <elements.hpp>
 #include<string>
 using namespace cycfi::elements;
-using namespace cycfi::artist;
 
 // Main window background color
 auto constexpr bkd_color = rgba(35, 35, 37, 255);
@@ -15,7 +14,7 @@ auto background = box(bkd_color);
 
 int main(int argc, char* argv[])
 {
-   app _app(argc, argv, "Empty Starter", "com.cycfi.empty-starter");
+   app _app(argc, argv, "SyncScrollbars", "com.cycfi.sync-scrollbars");
    window _win(_app.name());
    _win.on_close = [&_app]() { _app.stop(); };
 
@@ -28,27 +27,32 @@ int main(int argc, char* argv[])
        return share(label( "                        hello                              " + std::to_string(index)));
    };
 
-   auto comp = basic_vertical_cell_composer(10'000, make_cell);
-   auto l = share(vdynamic_list(comp));
+   // First dynamic list
+   auto comp = basic_cell_composer(10'000, make_cell);
+   auto l = share(dynamic_list(comp));
 
-   auto comp2 = basic_vertical_cell_composer(10'000, make_cell);
-   auto l2 = share(vdynamic_list(comp2));
+   // Second dynamic list
+   auto comp2 = basic_cell_composer(10'000, make_cell);
+   auto l2 = share(dynamic_list(comp2));
 
+   // Scrollers
    auto scr = vscroller(margin({20, 20, 20, 20}, hold(l)));
    auto scr2 = vscroller(margin({20, 20, 20, 20}, hold(l2)));
-   scr.on_scroll = [&](point bnds)
+   // Second scrollers will follow first scroller position
+   scr.on_scroll = [&](point p)
    {
-     scr2.set_position(bnds);
+     scr2.set_position(p);
      view_.layout();
      view_.refresh();
    };
 
    view_.content(
-
-               htile(scr, hspacer(100), link(scr2) ),
-
-      background     // Replace background with your main element,
-                     // or keep it and add another layer on top of it.
+    	   htile(
+		scr, 
+		hspacer(100), 
+		link(scr2) 
+		),
+      background     
    );
 
    _app.run();

--- a/examples/sync_scrollbars/main.cpp
+++ b/examples/sync_scrollbars/main.cpp
@@ -1,0 +1,56 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+
+   Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+#include <elements.hpp>
+#include<string>
+using namespace cycfi::elements;
+using namespace cycfi::artist;
+
+// Main window background color
+auto constexpr bkd_color = rgba(35, 35, 37, 255);
+auto background = box(bkd_color);
+
+
+int main(int argc, char* argv[])
+{
+   app _app(argc, argv, "Empty Starter", "com.cycfi.empty-starter");
+   window _win(_app.name());
+   _win.on_close = [&_app]() { _app.stop(); };
+
+   view view_(_win);
+
+   auto t = scroller(box(colors::red));
+
+   auto && make_cell = [&](size_t index)
+   {
+       return share(label( "                        hello                              " + std::to_string(index)));
+   };
+
+   auto comp = basic_vertical_cell_composer(10'000, make_cell);
+   auto l = share(vdynamic_list(comp));
+
+   auto comp2 = basic_vertical_cell_composer(10'000, make_cell);
+   auto l2 = share(vdynamic_list(comp2));
+
+   auto scr = vscroller(margin({20, 20, 20, 20}, hold(l)));
+   auto scr2 = vscroller(margin({20, 20, 20, 20}, hold(l2)));
+   scr.on_scroll = [&](point bnds)
+   {
+     scr2.set_position(bnds);
+     view_.layout();
+     view_.refresh();
+   };
+
+   view_.content(
+
+               htile(scr, hspacer(100), link(scr2) ),
+
+      background     // Replace background with your main element,
+                     // or keep it and add another layer on top of it.
+   );
+
+   _app.run();
+   return 0;
+}

--- a/lib/include/elements/element/port.hpp
+++ b/lib/include/elements/element/port.hpp
@@ -182,6 +182,9 @@ namespace cycfi { namespace elements
       bool                    cursor(context const& ctx, point p, cursor_tracking status) override;
       bool                    key(context const& ctx, key_info k) override;
 
+      std::function<void(point p)> on_scroll = [](point){};
+      void set_position(point p );
+
       struct scrollbar_info
       {
          double   pos;

--- a/lib/include/elements/element/port.hpp
+++ b/lib/include/elements/element/port.hpp
@@ -183,7 +183,7 @@ namespace cycfi { namespace elements
       bool                    key(context const& ctx, key_info k) override;
 
       std::function<void(point p)> on_scroll = [](point){};
-      void set_position(point p );
+      void set_position(point p);
 
       struct scrollbar_info
       {


### PR DESCRIPTION
* `std::function<void(point p)> on_scroll` lambda added to scroller_base (in `scroll`, and in `reposition`)
* `set_position(point p)` method added to `scroller_base` allowing to reposition the inside scroller (without calling `on_scroll` callback, since I use it to synchronize several scrollers, it would be infinite call). 