### PR TITLE
Homebrew installation path changed for M1 Macs

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -204,7 +204,11 @@ if (APPLE)
 endif()
 
 if (APPLE)
-   set(lib_dir "/usr/local/opt")
+   if(DEFINED ENV{HOMEBREW_PREFIX})
+     set(lib_dir $ENV{HOMEBREW_PREFIX}/opt)
+   else()
+     set(lib_dir "/usr/local/opt")
+   endif()
 endif()
 
 ###############################################################################


### PR DESCRIPTION
Homebrew is installed below '/opt/homebrew' instead of '/usr/local' for M1 based Macs.

See: https://docs.brew.sh/Installation

As a consequence the CMake script doesn't find libcairo.a. With this change, CMake checks if the HOMEBREW_PREFIX environment variable is set and sets lib_dir accordingly, otherwise falls back to previous behavior. 



