### PR TITLE
fix dynamic_list: subscript out of range in cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,5 @@ peer-reviewed, Open Source, collaborative development effort.
 
 -------------------------------------------------------------------------------
 
-*Copyright (c) 2014-2020 Joel de Guzman. All rights reserved.*
+*Copyright (c) 2014-2022 Joel de Guzman. All rights reserved.*
 *Distributed under the [MIT License](https://opensource.org/licenses/MIT)*

--- a/lib/src/element/dynamic_list.cpp
+++ b/lib/src/element/dynamic_list.cpp
@@ -81,7 +81,7 @@ namespace cycfi { namespace elements
       {
          for (auto i = _previous_window_start; i != _previous_window_end; ++i)
          {
-            if (i < new_start || i >= new_end)
+            if ((i < new_start || i >= new_end) && i < _cells.size())
             {
                _cells[i].layout_id = -1;
             }


### PR DESCRIPTION
When I tried to experience the [active_dynamic_list](https://github.com/cycfi/elements/tree/master/examples/active_dynamic_list) example, I found that clicking the "-" button in my environment (Windows 10, C++ 20, MSVC 2019, latest asio version) would cause the program to crash due to subscript out of bounds.

So I did a simple debug and fixed the problem :)