### PR TITLE
Added horizontal grid lines

### DIFF
--- a/lib/include/elements/element/misc.hpp
+++ b/lib/include/elements/element/misc.hpp
@@ -196,13 +196,33 @@ namespace cycfi { namespace elements
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   // Grid Lines
+   // Grid Lines - Vertical
    ////////////////////////////////////////////////////////////////////////////
    class vgrid_lines : public element
    {
    public:
 
                               vgrid_lines(float major_divisions, float minor_divisions)
+                               : _major_divisions(major_divisions)
+                               , _minor_divisions(minor_divisions)
+                              {}
+
+      void                    draw(context const& ctx) override;
+
+   private:
+
+      float                   _major_divisions;
+      float                   _minor_divisions;
+   };
+
+   ////////////////////////////////////////////////////////////////////////////
+   // Grid Lines - Horizontal
+   ////////////////////////////////////////////////////////////////////////////
+   class hgrid_lines : public element
+   {
+   public:
+
+                              hgrid_lines(float major_divisions, float minor_divisions)
                                : _major_divisions(major_divisions)
                                , _minor_divisions(minor_divisions)
                               {}

--- a/lib/src/element/misc.cpp
+++ b/lib/src/element/misc.cpp
@@ -63,6 +63,39 @@ namespace cycfi { namespace elements
       }
    }
 
+   void hgrid_lines::draw(context const& ctx)
+   {
+      auto const& theme_ = get_theme();
+      auto& canvas_ = ctx.canvas;
+      auto const& bounds = ctx.bounds;
+
+      float pos = bounds.left;
+      float incr = bounds.width() / _major_divisions;
+
+      canvas_.stroke_style(theme_.major_grid_color);
+      canvas_.line_width(theme_.major_grid_width);
+      while (pos <= bounds.right + 1)
+      {
+         canvas_.move_to({ pos, bounds.top });
+         canvas_.line_to({ pos, bounds.bottom });
+         canvas_.stroke();
+         pos += incr;
+      }
+
+      pos = bounds.left;
+      incr = bounds.width() / _minor_divisions;
+
+      canvas_.stroke_style(theme_.minor_grid_color);
+      canvas_.line_width(theme_.minor_grid_width);
+      while (pos <= bounds.right + 1)
+      {
+         canvas_.move_to({ pos, bounds.top });
+         canvas_.line_to({ pos, bounds.bottom });
+         canvas_.stroke();
+         pos += incr;
+      }
+   }
+
    icon::icon(std::uint32_t code_, float size_)
     : _code(code_)
     , _size(size_)


### PR DESCRIPTION
Currently, there's a function `vgrid_lines` that creates vertical lines spaced as requested. I added a function `hgrid_lines` that does basically the same, but it creates horizontal lines instead.