### PR TITLE
Implement X11 host UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include(ElementsConfigCommon)
 
 option(ELEMENTS_BUILD_EXAMPLES "build Elements library examples" ON)
 option(ELEMENTS_ENABLE_LTO "enable link time optimization for Elements targets" OFF)
-set(ELEMENTS_HOST_UI_LIBRARY "" CACHE STRING "gtk, cocoa or win32")
+set(ELEMENTS_HOST_UI_LIBRARY "" CACHE STRING "gtk, x11, cocoa or win32")
 option(ELEMENTS_HOST_ONLY_WIN7 "If host UI library is win32, reduce elements features to support Windows 7" OFF)
 
 add_subdirectory(lib)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -142,7 +142,6 @@ elseif (ELEMENTS_HOST_UI_LIBRARY STREQUAL "x11")
    set(ELEMENTS_HOST
       host/x11/app.cpp
       host/x11/base_view.cpp
-      host/x11/key.cpp
       host/x11/window.cpp
    )
 elseif (WIN32)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -142,6 +142,7 @@ elseif (ELEMENTS_HOST_UI_LIBRARY STREQUAL "x11")
    set(ELEMENTS_HOST
       host/x11/app.cpp
       host/x11/base_view.cpp
+      host/x11/key.cpp
       host/x11/window.cpp
    )
 elseif (WIN32)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -138,6 +138,13 @@ elseif (ELEMENTS_HOST_UI_LIBRARY STREQUAL "gtk")
       host/linux/key.cpp
       host/linux/window.cpp
    )
+elseif (ELEMENTS_HOST_UI_LIBRARY STREQUAL "x11")
+   set(ELEMENTS_HOST
+      host/x11/app.cpp
+      host/x11/base_view.cpp
+      host/x11/key.cpp
+      host/x11/window.cpp
+   )
 elseif (WIN32)
    set(ELEMENTS_HOST
       host/windows/utils.hpp
@@ -279,11 +286,14 @@ elseif (UNIX OR WIN32)
 endif()
 
 ###############################################################################
-# GTK (linux only)
+# GTK or X11 (linux only)
 
 if (ELEMENTS_HOST_UI_LIBRARY STREQUAL "gtk")
    pkg_check_modules(GTK3 REQUIRED IMPORTED_TARGET gtk+-3.0)
    target_link_libraries(elements PRIVATE PkgConfig::GTK3)
+elseif (ELEMENTS_HOST_UI_LIBRARY STREQUAL "x11")
+   find_package(X11 REQUIRED)
+   target_link_libraries(elements PRIVATE X11)
 endif()
 
 ###############################################################################
@@ -310,6 +320,8 @@ endif()
 
 if(ELEMENTS_HOST_UI_LIBRARY STREQUAL "gtk")
     target_compile_definitions(elements PUBLIC ELEMENTS_HOST_UI_LIBRARY_GTK)
+elseif(ELEMENTS_HOST_UI_LIBRARY STREQUAL "x11")
+    target_compile_definitions(elements PUBLIC ELEMENTS_HOST_UI_LIBRARY_X11)
 elseif(ELEMENTS_HOST_UI_LIBRARY STREQUAL "cocoa")
     if(NOT APPLE)
         message(FATAL_ERROR "Only macOS supports ELEMENTS_HOST_UI_LIBRARY=cocoa")
@@ -329,7 +341,7 @@ elseif(ELEMENTS_HOST_UI_LIBRARY STREQUAL "win32")
         target_compile_definitions(elements PRIVATE _WIN32_WINNT=0x0A00)
     endif()
 else()
-    message(FATAL_ERROR "Invalid ELEMENTS_HOST_UI_LIBRARY=${ELEMENTS_HOST_UI_LIBRARY}. Set gtk, cocoa or win32.")
+    message(FATAL_ERROR "Invalid ELEMENTS_HOST_UI_LIBRARY=${ELEMENTS_HOST_UI_LIBRARY}. Set gtk, x11, cocoa or win32.")
 endif()
 
 ###############################################################################

--- a/lib/host/linux/app.cpp
+++ b/lib/host/linux/app.cpp
@@ -99,6 +99,11 @@ namespace cycfi { namespace elements
       g_application_run(G_APPLICATION(_app), argc, argv);
    }
 
+   bool app::tick()
+   {
+      return gtk_main_iteration();
+   }
+
    void app::stop()
    {
       g_application_release(G_APPLICATION(_app));

--- a/lib/host/x11/app.cpp
+++ b/lib/host/x11/app.cpp
@@ -65,19 +65,14 @@ namespace cycfi { namespace elements
       //XCloseDisplay(the_display);
    }
 
-   void app::run()
-   {
-      do {} while(tick());
-   }
-
    bool on_event(base_view *, const XEvent&);
 
-   bool app::tick()
+   static bool event_loop(bool block_for_event)
    {
       XEvent event;
       bool result = true;
 
-      while(XPending(the_display) > 0) {
+      while(block_for_event || XPending(the_display) > 0) {
          XNextEvent(the_display, &event);
 
          base_view* view = gs_windows_map[event.xany.window];
@@ -95,6 +90,16 @@ namespace cycfi { namespace elements
       }
 
       return result;
+   }
+
+   bool app::tick()
+   {
+      return event_loop(false);
+   }
+
+   void app::run()
+   {
+      do {} while(event_loop(true));
    }
 
    void app::stop()

--- a/lib/host/x11/app.cpp
+++ b/lib/host/x11/app.cpp
@@ -1,0 +1,99 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+
+   Distributed under the MIT License [ https://opensource.org/licenses/MIT ]
+=============================================================================*/
+#include <elements/app.hpp>
+#include <elements/support/font.hpp>
+#include <elements/support/resource_paths.hpp>
+#include <elements/base_view.hpp>
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+
+#include <cairo/cairo.h>
+
+namespace cycfi { namespace elements
+{
+   // Some app globals
+   char** argv = nullptr;
+
+   std::unordered_map<Window, base_view*> gs_windows_map;
+
+   Display* the_display = XOpenDisplay(nullptr);
+   Display* get_display()
+   {
+      return the_display;
+   }
+
+   fs::path find_resources()
+   {
+      const fs::path app_path = fs::path(argv[0]);
+      const fs::path app_dir = app_path.parent_path();
+
+      if (app_dir.filename() == "bin")
+      {
+         fs::path path = app_dir.parent_path() / "share" / app_path.filename() / "resources";
+         if (fs::is_directory(path))
+            return path;
+      }
+
+       const fs::path app_resources_dir = app_dir / "resources";
+       if (fs::is_directory(app_resources_dir))
+          return app_resources_dir;
+
+       return fs::current_path() / "resources";
+   }
+
+   app::app(
+     int       /*argc_*/
+   , char*       argv_[]
+   , std::string name
+   , std::string /*id*/
+   )
+   : _app_name(name)
+   {
+      argv = argv_;
+      const fs::path resources_path = find_resources();
+      font_paths().push_back(resources_path);
+      add_search_path(resources_path);
+   }
+
+   app::~app()
+   {
+      XCloseDisplay(the_display);
+   }
+
+   void app::run()
+   {
+      XEvent event;
+      while (1)
+      {
+         XNextEvent(the_display, &event);
+         switch(event.type)
+         {
+            case Expose:
+            {
+               XClearWindow(the_display, event.xexpose.window);
+               base_view* view = gs_windows_map[event.xexpose.window];
+               if (view)
+                  on_draw(view);
+
+               break;
+            }
+            case ClientMessage:
+            {
+               Atom wm_delete_window = XInternAtom(the_display, "WM_DELETE_WINDOW", True);
+               if (static_cast<Atom>(event.xclient.data.l[0]) == wm_delete_window) {
+                  return;
+               }
+               break;
+            }
+         }
+      }
+   }
+
+   void app::stop()
+   {
+   }
+}}

--- a/lib/host/x11/base_view.cpp
+++ b/lib/host/x11/base_view.cpp
@@ -1,0 +1,220 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+
+   Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+#include <elements/app.hpp>
+#include <cairo.h>
+#include <infra/assert.hpp>
+#include <elements/base_view.hpp>
+#include <elements/window.hpp>
+#include <elements/support/resource_paths.hpp>
+
+#include <X11/Xlib.h>
+#include <cairo-xlib.h>
+
+#include <unordered_map>
+
+namespace cycfi { namespace elements
+{
+   struct host_view
+   {
+      host_view();
+      ~host_view();
+
+      Window native;
+      cairo_surface_t* surface = nullptr;
+   };
+
+   host_view::host_view()
+   {
+   }
+
+   host_view::~host_view()
+   {
+      if (surface)
+         cairo_surface_destroy(surface);
+
+      surface = nullptr;
+   }
+
+   Window make_view(base_view& view, Window parent)
+   {
+      Display* display = XOpenDisplay(nullptr);
+      int screen = DefaultScreen(display);
+      XWindowAttributes attributes;
+
+      XGetWindowAttributes(display, parent, &attributes);
+
+      Window content_view = XCreateSimpleWindow
+      (
+         display,
+         parent,
+         0,
+         0,
+         attributes.width,
+         attributes.height,
+         attributes.border_width,
+         XWhitePixel(display, screen),
+         XWhitePixel(display, screen)
+      );
+
+      extern std::unordered_map<Window, base_view*> gs_windows_map;
+      gs_windows_map[content_view] = &view;
+
+      // TODO: to remove, just for testing
+      XColor bgcolor;
+      Colormap cmap = DefaultColormap(display, screen);
+      bgcolor.red = 65000;
+      bgcolor.green = 0;
+      bgcolor.blue = 65000;
+
+      if (XAllocColor(display, cmap, &bgcolor))
+         XSetWindowBackground(display, content_view, bgcolor.pixel);
+
+      XSelectInput
+      (
+         display,
+         content_view,
+         ExposureMask
+         | ButtonPressMask
+         | ButtonReleaseMask
+         | EnterWindowMask
+         | LeaveWindowMask
+         | PointerMotionMask
+         | FocusChangeMask
+         | KeyPressMask
+         | KeyReleaseMask
+         | SubstructureNotifyMask
+      );
+
+      XMapWindow(display, content_view);
+
+      XFlush(display);
+
+      return content_view;
+   }
+
+   struct platform_access
+   {
+      inline static host_view* get_host_view(base_view& view)
+      {
+         return view.host();
+      }
+   };
+
+   void on_draw(base_view *view)
+   {
+      auto* host_view_h = view->host();
+      Display* display = XOpenDisplay(nullptr);
+      XWindowAttributes attributes;
+      XGetWindowAttributes(display, host_view_h->native, &attributes);
+
+      host_view_h->surface = cairo_xlib_surface_create(
+         display,
+         host_view_h->native,
+         attributes.visual,
+         attributes.width,
+         attributes.height
+      );
+
+      cairo_xlib_surface_set_size(host_view_h->surface, attributes.width, attributes.height);
+      cairo_t* context = cairo_create(host_view_h->surface);
+
+      double left, top, right, bottom;
+      cairo_clip_extents(context, &left, &top, &right, &bottom);
+      view->draw(
+         context,
+         rect{ float(left), float(top), float(right), float(bottom) }
+      );
+      cairo_destroy(context);
+      cairo_surface_destroy(host_view_h->surface);
+   }
+
+   // Defined in window.cpp
+   Window get_window(host_window& h);
+
+   struct init_view_class
+   {
+      init_view_class()
+      {
+         auto pwd = fs::current_path();
+         auto resource_path = pwd / "resources";
+         add_search_path(resource_path);
+      }
+   };
+
+    base_view::base_view(extent /* size_ */)
+    : base_view(new host_view)
+    {
+        // $$$ FIXME: Implement Me $$$
+        CYCFI_ASSERT(false, "Unimplemented");
+    }
+
+   base_view::base_view(host_view_handle h)
+    : _view(h)
+   {
+      static init_view_class init;
+   }
+
+   base_view::base_view(host_window_handle h)
+    : base_view(new host_view)
+   {
+       _view->native = elements::make_view(*this, get_window(*h));
+   }
+
+   base_view::~base_view()
+   {
+      delete _view;
+   }
+
+   point base_view::cursor_pos() const
+   {
+      return point(); // TODO
+   }
+
+   elements::extent base_view::size() const
+   {
+       return {0.0, 0.0}; // TODO
+   }
+
+   void base_view::size(elements::extent p)
+   {
+      (void)p; // TODO
+   }
+
+   float base_view::hdpi_scale() const
+   {
+      return 1.0f;
+   }
+
+   void base_view::refresh()
+   {
+      // TODO
+   }
+
+   void base_view::refresh(rect area)
+   {
+      (void)area; // TODO
+   }
+
+   std::string clipboard()
+   {
+      return std::string(); // TODO
+   }
+
+   void clipboard(std::string const& text)
+   {
+      (void)text; // TODO
+   }
+
+   void set_cursor(cursor_type type)
+   {
+      (void)type; // TODO
+   }
+
+   point scroll_direction()
+   {
+      return { +1.0f, +1.0f };
+   }
+}}

--- a/lib/host/x11/base_view.cpp
+++ b/lib/host/x11/base_view.cpp
@@ -4,43 +4,43 @@
    Distributed under the MIT License (https://opensource.org/licenses/MIT)
 =============================================================================*/
 #include <elements/app.hpp>
-#include <cairo.h>
 #include <infra/assert.hpp>
 #include <elements/base_view.hpp>
 #include <elements/window.hpp>
 #include <elements/support/resource_paths.hpp>
 
 #include <X11/Xlib.h>
+#include <X11/cursorfont.h>
+#include <cairo.h>
 #include <cairo-xlib.h>
 
+#include <iostream>
 #include <unordered_map>
 
 namespace cycfi { namespace elements
 {
+   Display* get_display();
+
    struct host_view
    {
-      host_view();
+      host_view(base_view& view, Window parent);
       ~host_view();
 
-      Window native;
+      Window x_window;
       cairo_surface_t* surface = nullptr;
+      cairo_t* context = nullptr;
+      unsigned int last_cursor_shape = XC_X_cursor;
    };
 
-   host_view::host_view()
-   {
+   namespace {
+      // set_cursor is not provided with a base_view context, so we must keep
+      // track of the one the user is pointing to
+      host_view *host_view_under_cursor = nullptr;
    }
 
-   host_view::~host_view()
+   host_view::host_view(base_view& view, Window parent)
    {
-      if (surface)
-         cairo_surface_destroy(surface);
-
-      surface = nullptr;
-   }
-
-   Window make_view(base_view& view, Window parent)
-   {
-      Display* display = XOpenDisplay(nullptr);
+      Display* display = get_display();
       int screen = DefaultScreen(display);
       XWindowAttributes attributes;
 
@@ -54,15 +54,20 @@ namespace cycfi { namespace elements
          0,
          attributes.width,
          attributes.height,
-         attributes.border_width,
+         0, // border_width
          XWhitePixel(display, screen),
          XWhitePixel(display, screen)
       );
+      x_window = content_view;
+
+
+      // TODO StructureNotify on parent
+
 
       extern std::unordered_map<Window, base_view*> gs_windows_map;
       gs_windows_map[content_view] = &view;
 
-      // TODO: to remove, just for testing
+      /* Debug: paint window background magenta
       XColor bgcolor;
       Colormap cmap = DefaultColormap(display, screen);
       bgcolor.red = 65000;
@@ -71,6 +76,7 @@ namespace cycfi { namespace elements
 
       if (XAllocColor(display, cmap, &bgcolor))
          XSetWindowBackground(display, content_view, bgcolor.pixel);
+      */
 
       XSelectInput
       (
@@ -92,43 +98,147 @@ namespace cycfi { namespace elements
 
       XFlush(display);
 
-      return content_view;
-   }
-
-   struct platform_access
-   {
-      inline static host_view* get_host_view(base_view& view)
-      {
-         return view.host();
-      }
-   };
-
-   void on_draw(base_view *view)
-   {
-      auto* host_view_h = view->host();
-      Display* display = XOpenDisplay(nullptr);
-      XWindowAttributes attributes;
-      XGetWindowAttributes(display, host_view_h->native, &attributes);
-
-      host_view_h->surface = cairo_xlib_surface_create(
+      surface = cairo_xlib_surface_create(
          display,
-         host_view_h->native,
+         content_view,
          attributes.visual,
          attributes.width,
          attributes.height
       );
 
+      context = cairo_create(surface);
+   }
+
+   host_view::~host_view()
+   {
+      cairo_destroy(context);
+      cairo_surface_destroy(surface);
+      if (host_view_under_cursor == this)
+         host_view_under_cursor = nullptr;
+   }
+
+   static void on_draw(base_view *view, rect area)
+   {
+      view->draw(view->host()->context, area);
+      XFlush(get_display());
+   }
+
+   static void on_draw(base_view *view, const XExposeEvent& event)
+   {
+      on_draw(view, rect{float(event.x), float(event.y),
+                         float(event.x + event.width), float(event.y + event.height)});
+   }
+
+   static void on_draw(base_view *view)
+   {
+      auto* host_view_h = view->host();
+      Display* display = get_display();
+      XWindowAttributes attributes;
+      XGetWindowAttributes(display, host_view_h->x_window, &attributes);
+
+      // TODO move to resize handler
       cairo_xlib_surface_set_size(host_view_h->surface, attributes.width, attributes.height);
-      cairo_t* context = cairo_create(host_view_h->surface);
 
       double left, top, right, bottom;
-      cairo_clip_extents(context, &left, &top, &right, &bottom);
-      view->draw(
-         context,
-         rect{ float(left), float(top), float(right), float(bottom) }
-      );
-      cairo_destroy(context);
-      cairo_surface_destroy(host_view_h->surface);
+      cairo_clip_extents(host_view_h->context, &left, &top, &right, &bottom);
+
+      /* Debug: paint background red
+      cairo_set_source_rgb(host_view_h->context, 255, 0, 0);
+      cairo_paint(host_view_h->context);
+      */
+
+      on_draw(view, rect{ float(left), float(top), float(right), float(bottom) });
+   }
+
+   template<typename XEvent>
+   void get_mouse(const XEvent& event, mouse_button& btn)
+   {
+      btn.pos = { float(event.x), float(event.y) };
+      btn.modifiers = 0; // TODO
+   }
+
+   static void on_button(base_view *view, const XButtonEvent& event)
+   {
+      mouse_button btn = {};
+      get_mouse(event, btn);
+      btn.state = (event.button == Button1) ? mouse_button::left
+                : (event.button == Button2) ? mouse_button::middle
+                :                             mouse_button::right;
+      btn.num_clicks = 1; // TODO count double click like GTK
+      btn.down = event.type == ButtonPress;
+
+      view->click(btn);
+   }
+
+   static void on_pointer(base_view *view, const XPointerMovedEvent& event)
+   {
+      mouse_button btn = {};
+      get_mouse(event, btn);
+      btn.state = (event.state & Button1Mask) ? mouse_button::left
+                : (event.state & Button2Mask) ? mouse_button::middle
+                :                               mouse_button::right;
+      btn.down = (event.state & (Button1Mask | Button2Mask | Button3Mask)) != 0;
+      if(btn.down) {
+         view->drag(btn);
+      } else {
+         view->cursor(btn.pos, cursor_tracking::hovering);
+      }
+   }
+
+   static void on_crossing(base_view *view, const XCrossingEvent& event)
+   {
+      point pos { float(event.x), float(event.y) };
+      if(event.type == EnterNotify) {
+         host_view_under_cursor = view->host();
+         view->cursor(pos, cursor_tracking::entering);
+      } else {
+         host_view_under_cursor = nullptr;
+         view->cursor(pos, cursor_tracking::entering);
+      }
+   }
+
+   static void on_key(base_view *view, const XKeyEvent& event)
+   {
+   }
+
+   bool on_event(base_view *view, const XEvent& event)
+   {
+      switch(event.type)
+      {
+         case Expose:
+            on_draw(view, event.xexpose);
+            break;
+         case MotionNotify:
+            on_pointer(view, event.xmotion);
+            break;
+         case ButtonPress:
+         case ButtonRelease:
+            on_button(view, event.xbutton);
+            break;
+         case EnterNotify:
+         case LeaveNotify:
+            on_crossing(view, event.xcrossing);
+            break;
+         case FocusIn:
+            view->begin_focus();
+            break;
+         case FocusOut:
+            view->end_focus();
+            break;
+         case KeyPress:
+         case KeyRelease:
+            on_key(view, event.xkey);
+            break;
+         case ClientMessage:
+         {
+            Atom wm_delete_window = XInternAtom(get_display(), "WM_DELETE_WINDOW", True);
+            if (static_cast<Atom>(event.xclient.data.l[0]) == wm_delete_window) {
+               return false;
+            }
+            break;
+         }
+      }
+      return true;
    }
 
    // Defined in window.cpp
@@ -145,7 +255,7 @@ namespace cycfi { namespace elements
    };
 
     base_view::base_view(extent /* size_ */)
-    : base_view(new host_view)
+    : base_view(new host_view(*this, 0))
     {
         // $$$ FIXME: Implement Me $$$
         CYCFI_ASSERT(false, "Unimplemented");
@@ -158,9 +268,8 @@ namespace cycfi { namespace elements
    }
 
    base_view::base_view(host_window_handle h)
-    : base_view(new host_view)
+    : base_view(new host_view(*this, get_window(*h)))
    {
-       _view->native = elements::make_view(*this, get_window(*h));
    }
 
    base_view::~base_view()
@@ -170,17 +279,29 @@ namespace cycfi { namespace elements
 
    point base_view::cursor_pos() const
    {
-      return point(); // TODO
+      Window root, child;
+      int root_x, root_y;
+      int child_x, child_y;
+      unsigned int mask;
+
+      XQueryPointer(get_display(), _view->x_window,
+                    &root, &child, &root_x, &root_y, &child_x, &child_y, &mask);
+      return {float(child_x), float(child_y)};
    }
 
    elements::extent base_view::size() const
    {
-       return {0.0, 0.0}; // TODO
+       Window root;
+       int x, y;
+       unsigned int w = 0, h = 0, border_w, depth;
+       XGetGeometry(get_display(), _view->x_window , &root, &x, &y, &w, &h, &border_w, &depth);
+       return {float(w), float(h)};
    }
 
    void base_view::size(elements::extent p)
    {
-      (void)p; // TODO
+       std::cerr << "base_view::size(extent)" << std::endl;
+       (void)p; // TODO
    }
 
    float base_view::hdpi_scale() const
@@ -190,27 +311,57 @@ namespace cycfi { namespace elements
 
    void base_view::refresh()
    {
-      // TODO
+      on_draw(this);
    }
 
    void base_view::refresh(rect area)
    {
-      (void)area; // TODO
+      on_draw(this, area);
    }
 
    std::string clipboard()
    {
+      std::cerr << "base_view::clipboard()" << std::endl;
       return std::string(); // TODO
    }
 
    void clipboard(std::string const& text)
    {
+      std::cerr << "base_view::clipboard(std::string const&)" << std::endl;
       (void)text; // TODO
    }
 
    void set_cursor(cursor_type type)
    {
-      (void)type; // TODO
+      unsigned int new_shape;
+      switch (type)
+      {
+         case cursor_type::ibeam:
+            new_shape = XC_xterm;
+            break;
+         case cursor_type::cross_hair:
+            new_shape = XC_crosshair;
+            break;
+         case cursor_type::hand:
+            new_shape = XC_hand2;
+            break;
+         case cursor_type::h_resize:
+            new_shape = XC_sb_h_double_arrow;
+            break;
+         case cursor_type::v_resize:
+            new_shape = XC_sb_v_double_arrow;
+            break;
+         default:
+         case cursor_type::arrow:
+            new_shape = XC_left_ptr;
+            break;
+      }
+      if(host_view_under_cursor != nullptr && host_view_under_cursor->last_cursor_shape != new_shape) {
+         Display* display = get_display();
+         Cursor c = XCreateFontCursor(display, new_shape);
+         XDefineCursor(display, host_view_under_cursor->x_window, c);
+         host_view_under_cursor->last_cursor_shape = new_shape;
+      }
    }
 
    point scroll_direction()

--- a/lib/host/x11/base_view.cpp
+++ b/lib/host/x11/base_view.cpp
@@ -120,7 +120,10 @@ namespace cycfi { namespace elements
 
    static void on_draw(base_view *view, rect area)
    {
+      cairo_push_group_with_content(view->host()->context, CAIRO_CONTENT_COLOR);
       view->draw(view->host()->context, area);
+      cairo_pop_group_to_source(view->host()->context);
+      cairo_paint(view->host()->context);
       XFlush(get_display());
    }
 

--- a/lib/host/x11/key.cpp
+++ b/lib/host/x11/key.cpp
@@ -1,0 +1,155 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+   Copyright (c) 2022 George Hilliard
+
+   Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+#include <elements/base_view.hpp>
+
+#include <X11/Xlib.h>
+#include <X11/keysym.h>
+
+namespace cycfi { namespace elements
+{
+   key_code translate_key(KeySym key)
+   {
+      switch (key)
+      {
+         default:    return key_code::unknown;
+
+         case XK_0:  return key_code:: _0;
+         case XK_1:  return key_code:: _1;
+         case XK_2:  return key_code:: _2;
+         case XK_3:  return key_code:: _3;
+         case XK_4:  return key_code:: _4;
+         case XK_5:  return key_code:: _5;
+         case XK_6:  return key_code:: _6;
+         case XK_7:  return key_code:: _7;
+         case XK_8:  return key_code:: _8;
+         case XK_9:  return key_code:: _9;
+
+         case XK_a:  return key_code::a;
+         case XK_b:  return key_code::b;
+         case XK_c:  return key_code::c;
+         case XK_d:  return key_code::d;
+         case XK_e:  return key_code::e;
+         case XK_f:  return key_code::f;
+         case XK_g:  return key_code::g;
+         case XK_h:  return key_code::h;
+         case XK_i:  return key_code::i;
+         case XK_j:  return key_code::j;
+         case XK_k:  return key_code::k;
+         case XK_l:  return key_code::l;
+         case XK_m:  return key_code::m;
+         case XK_n:  return key_code::n;
+         case XK_o:  return key_code::o;
+         case XK_p:  return key_code::p;
+         case XK_q:  return key_code::q;
+         case XK_r:  return key_code::r;
+         case XK_s:  return key_code::s;
+         case XK_t:  return key_code::t;
+         case XK_u:  return key_code::u;
+         case XK_v:  return key_code::v;
+         case XK_w:  return key_code::w;
+         case XK_x:  return key_code::x;
+         case XK_y:  return key_code::y;
+         case XK_z:  return key_code::z;
+
+         case XK_apostrophe:   return key_code::apostrophe;
+         case XK_backslash:    return key_code::backslash;
+         case XK_comma:        return key_code::comma;
+         case XK_equal:        return key_code::equal;
+         case XK_grave:        return key_code::grave_accent;
+         case XK_bracketleft:  return key_code::left_bracket;
+         case XK_minus:        return key_code::minus;
+         case XK_period:       return key_code::period;
+         case XK_bracketright: return key_code::right_bracket;
+         case XK_semicolon:    return key_code::semicolon;
+         case XK_slash:        return key_code::slash;
+
+         case XK_BackSpace:    return key_code::backspace;
+         case XK_Delete:       return key_code::_delete;
+         case XK_End:          return key_code::end;
+
+         case XK_Return:
+         case XK_ISO_Enter:    return key_code::enter;
+
+         case XK_Escape:       return key_code::escape;
+         case XK_Home:         return key_code::home;
+         case XK_Insert:       return key_code::insert;
+         case XK_Menu:         return key_code::menu;
+         case XK_Page_Down:    return key_code::page_down;
+         case XK_Page_Up:      return key_code::page_up;
+         case XK_Pause:        return key_code::pause;
+         case XK_space:        return key_code::space;
+
+         case XK_Tab:
+         case XK_KP_Tab:
+         case XK_ISO_Left_Tab:
+                               return key_code::tab;
+
+         case XK_Caps_Lock:    return key_code::caps_lock;
+         case XK_Num_Lock:     return key_code::num_lock;
+         case XK_Scroll_Lock:  return key_code::scroll_lock;
+
+         case XK_F1:     return key_code::f1;
+         case XK_F2:     return key_code::f2;
+         case XK_F3:     return key_code::f3;
+         case XK_F4:     return key_code::f4;
+         case XK_F5:     return key_code::f5;
+         case XK_F6:     return key_code::f6;
+         case XK_F7:     return key_code::f7;
+         case XK_F8:     return key_code::f8;
+         case XK_F9:     return key_code::f9;
+         case XK_F10:    return key_code::f10;
+         case XK_F11:    return key_code::f11;
+         case XK_F12:    return key_code::f12;
+         case XK_F13:    return key_code::f13;
+         case XK_F14:    return key_code::f14;
+         case XK_F15:    return key_code::f15;
+         case XK_F16:    return key_code::f16;
+         case XK_F17:    return key_code::f17;
+         case XK_F18:    return key_code::f18;
+         case XK_F19:    return key_code::f19;
+         case XK_F20:    return key_code::f20;
+         case XK_F21:    return key_code::f21;
+         case XK_F22:    return key_code::f22;
+         case XK_F23:    return key_code::f23;
+         case XK_F24:    return key_code::f24;
+
+         case XK_Alt_L:     return key_code::left_alt;
+         case XK_Control_L: return key_code::left_control;
+         case XK_Shift_L:   return key_code::left_shift;
+         case XK_Super_L:   return key_code::left_super;
+         case XK_Print:     return key_code::print_screen;
+         case XK_Alt_R:     return key_code::right_alt;
+         case XK_Control_R: return key_code::right_control;
+         case XK_Shift_R:   return key_code::right_shift;
+         case XK_Super_R:   return key_code::right_super;
+         case XK_Down:      return key_code::down;
+         case XK_Left:      return key_code::left;
+         case XK_Right:     return key_code::right;
+         case XK_Up:        return key_code::up;
+
+         case XK_KP_0:  return key_code::kp_0;
+         case XK_KP_1:  return key_code::kp_1;
+         case XK_KP_2:  return key_code::kp_2;
+         case XK_KP_3:  return key_code::kp_3;
+         case XK_KP_4:  return key_code::kp_4;
+         case XK_KP_5:  return key_code::kp_5;
+         case XK_KP_6:  return key_code::kp_6;
+         case XK_KP_7:  return key_code::kp_7;
+         case XK_KP_8:  return key_code::kp_8;
+         case XK_KP_9:  return key_code::kp_9;
+
+         case XK_KP_Add:       return key_code::kp_add;
+         case XK_KP_Decimal:   return key_code::kp_decimal;
+         case XK_KP_Divide:    return key_code::kp_divide;
+         case XK_KP_Enter:     return key_code::kp_enter;
+         case XK_KP_Equal:     return key_code::kp_equal;
+         case XK_KP_Multiply:  return key_code::kp_multiply;
+         case XK_KP_Subtract:  return key_code::kp_subtract;
+      }
+   }
+}}
+

--- a/lib/host/x11/window.cpp
+++ b/lib/host/x11/window.cpp
@@ -5,7 +5,7 @@
 =============================================================================*/
 #include <elements/window.hpp>
 #include <X11/Xlib.h>
-#include <X11/Xlib.h>
+#include <iostream>
 
 namespace cycfi { namespace elements
 {
@@ -31,6 +31,7 @@ namespace cycfi { namespace elements
         XSetWindowAttributes attributes;
         attributes.background_pixel = XWhitePixel(display, screen);
 
+        // TODO SubstructureNotify for detecting child resizing
         _window->host = XCreateWindow(
             display,
             RootWindow(display, screen),
@@ -42,7 +43,7 @@ namespace cycfi { namespace elements
             CWBackPixel,
             &attributes);
 
-        XSelectInput(display, _window->host, ExposureMask | KeyPressMask);
+        XSelectInput(display, _window->host, ExposureMask | KeyPressMask | ButtonPressMask | ButtonReleaseMask);
         XMapWindow(display, _window->host);
         XStoreName(display, _window->host, name.c_str());
 
@@ -60,22 +61,32 @@ namespace cycfi { namespace elements
 
     point window::size() const
     {
-        return point(); // TODO
+        Window root;
+        int x, y;
+        unsigned int w = 0, h = 0, border_w, depth;
+        XGetGeometry(get_display(), _window->host, &root, &x, &y, &w, &h, &border_w, &depth);
+        return {static_cast<float>(w), static_cast<float>(h)};
     }
 
     void window::size(point const& p)
     {
-        (void)p; // TODO
+        XResizeWindow(get_display(), _window->host, p.x, p.y);
     }
 
     void window::limits(view_limits limits_)
     {
+        std::cerr << "window::limits(view_limits)" << std::endl;
         (void)limits_; // TODO
     }
 
     point window::position() const
     {
-        return point(); // TODO
+        Display* display = get_display();
+        int screen = DefaultScreen(display);
+        int x, y;
+        Window child;
+        XTranslateCoordinates(display, _window->host, RootWindow(display, screen), 0, 0, &x, &y, &child );
+        return {static_cast<float>(x), static_cast<float>(y)};
     }
 
     void window::position(point const& p)

--- a/lib/host/x11/window.cpp
+++ b/lib/host/x11/window.cpp
@@ -5,6 +5,7 @@
 =============================================================================*/
 #include <elements/window.hpp>
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 #include <iostream>
 
 namespace cycfi { namespace elements
@@ -75,8 +76,14 @@ namespace cycfi { namespace elements
 
     void window::limits(view_limits limits_)
     {
-        std::cerr << "window::limits(view_limits)" << std::endl;
-        (void)limits_; // TODO
+        XSizeHints hints = {};
+        hints.flags = PMinSize | PMaxSize;
+        hints.min_width = limits_.min.x;
+        hints.min_height = limits_.min.y;
+        hints.max_width = limits_.max.x;
+        hints.max_height = limits_.max.y;
+
+        XSetWMNormalHints(get_display(), _window->host, &hints);
     }
 
     point window::position() const

--- a/lib/host/x11/window.cpp
+++ b/lib/host/x11/window.cpp
@@ -1,0 +1,85 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+
+   Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+#include <elements/window.hpp>
+#include <X11/Xlib.h>
+#include <X11/Xlib.h>
+
+namespace cycfi { namespace elements
+{
+    struct host_window
+    {
+        Window host;
+    };
+
+    Display* get_display();
+    Window get_window(host_window& h)
+    {
+        return h.host;
+    }
+
+    window::window(std::string const& name, int /*style_*/, rect const& bounds)
+    : _window(new host_window)
+    {
+        Display* display = get_display();
+        int screen = DefaultScreen(display);
+        int depth  = DefaultDepth(display, screen);
+        int border = 1;
+        Visual *visual = DefaultVisual(display, screen);
+        XSetWindowAttributes attributes;
+        attributes.background_pixel = XWhitePixel(display, screen);
+
+        _window->host = XCreateWindow(
+            display,
+            RootWindow(display, screen),
+            bounds.top, bounds.left, bounds.right, bounds.bottom,
+            border,
+            depth,
+            InputOutput,
+            visual,
+            CWBackPixel,
+            &attributes);
+
+        XSelectInput(display, _window->host, ExposureMask | KeyPressMask);
+        XMapWindow(display, _window->host);
+        XStoreName(display, _window->host, name.c_str());
+
+        Atom wm_delete_window = XInternAtom(get_display(), "WM_DELETE_WINDOW", True);
+        XSetWMProtocols(display, _window->host, &wm_delete_window, 1);
+        XFlush(display);
+    }
+
+    window::~window()
+    {
+        on_close(); // FIXME: move where make possible to veto the event
+        XDestroyWindow(get_display(), _window->host);
+        delete _window;
+    }
+
+    point window::size() const
+    {
+        return point(); // TODO
+    }
+
+    void window::size(point const& p)
+    {
+        (void)p; // TODO
+    }
+
+    void window::limits(view_limits limits_)
+    {
+        (void)limits_; // TODO
+    }
+
+    point window::position() const
+    {
+        return point(); // TODO
+    }
+
+    void window::position(point const& p)
+    {
+        (void)p; // TODO
+    }
+}}

--- a/lib/include/elements/app.hpp
+++ b/lib/include/elements/app.hpp
@@ -38,6 +38,8 @@ namespace cycfi { namespace elements
       void* _menubar;
 #elif defined(ELEMENTS_HOST_UI_LIBRARY_GTK)
       GtkApplication* _app;
+#elif defined(ELEMENTS_HOST_UI_LIBRARY_X11)
+
 #elif defined(ELEMENTS_HOST_UI_LIBRARY_WIN32)
       bool  _running = true;
 #endif

--- a/lib/include/elements/app.hpp
+++ b/lib/include/elements/app.hpp
@@ -30,6 +30,7 @@ namespace cycfi { namespace elements
 
       std::string const&   name() const { return _app_name; }
       void                 run();
+      bool                 tick();
       void                 stop();
 
    private:

--- a/lib/include/elements/base_view.hpp
+++ b/lib/include/elements/base_view.hpp
@@ -278,7 +278,9 @@ namespace cycfi { namespace elements
    // The base view base class
    ////////////////////////////////////////////////////////////////////////////
 
-#if defined(ELEMENTS_HOST_UI_LIBRARY_COCOA) || defined(ELEMENTS_HOST_UI_LIBRARY_GTK)
+#if defined(ELEMENTS_HOST_UI_LIBRARY_COCOA)\
+ || defined(ELEMENTS_HOST_UI_LIBRARY_GTK)\
+ || defined(ELEMENTS_HOST_UI_LIBRARY_X11)
    struct host_view;
    using host_view_handle = host_view*;
    struct host_window;
@@ -294,7 +296,9 @@ namespace cycfi { namespace elements
    {
    public:
 
-#if defined(ELEMENTS_HOST_UI_LIBRARY_COCOA) || defined(ELEMENTS_HOST_UI_LIBRARY_GTK)
+#if defined(ELEMENTS_HOST_UI_LIBRARY_COCOA)\
+ || defined(ELEMENTS_HOST_UI_LIBRARY_GTK)\
+ || defined(ELEMENTS_HOST_UI_LIBRARY_X11)
                            base_view(host_view_handle h);
 #endif
                            base_view(extent size_);
@@ -325,7 +329,9 @@ namespace cycfi { namespace elements
 
       host_view_handle     _view;
    };
-
+#if defined(ELEMENTS_HOST_UI_LIBRARY_X11)
+   void on_draw(base_view *);
+#endif
    ////////////////////////////////////////////////////////////////////////////
    inline void base_view::draw(cairo_t* /* ctx */, rect /* area */) {}
    inline void base_view::click(mouse_button /* btn */) {}

--- a/lib/include/elements/base_view.hpp
+++ b/lib/include/elements/base_view.hpp
@@ -329,9 +329,6 @@ namespace cycfi { namespace elements
 
       host_view_handle     _view;
    };
-#if defined(ELEMENTS_HOST_UI_LIBRARY_X11)
-   void on_draw(base_view *);
-#endif
    ////////////////////////////////////////////////////////////////////////////
    inline void base_view::draw(cairo_t* /* ctx */, rect /* area */) {}
    inline void base_view::click(mouse_button /* btn */) {}


### PR DESCRIPTION
This PR adds a straight Xlib host UI implementation.  It also provides a couple of amenities for developing plugins, ~namely allowing providing a `native_window_handle` to constructors to allow client code to manage window creation~, and `app::tick()` for running a single UI iteration.

It is still a work in progress.  Notable limitations:

- [x] The other ports do not handle the `native_window_handle` argument to the `window` constructor
- [ ] The clipboard is not implemented
- [x] Double clicks are not yet detected
- [ ] Display scaling is not detected; this may require some opportunistic hacks or DBus calls, I have not researched.
- [ ] IME handling for non-English languages is basically untested (pointers on "easy mode" for testing e.g. pinyin input would be greatly appreciated)
- [x] The macOS port doesn't build because apparently Objective C classes (`NSWindow`) cannot be named from pure C++ code - still figuring this out.