### PR TITLE
C++20 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 
 project(elements LANGUAGES C CXX)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,12 @@
 cmake_minimum_required(VERSION 3.9.6...3.15.0)
 
 project(elements LANGUAGES C CXX)
-set(CMAKE_CXX_STANDARD 20)
 
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+if(CMAKE_CXX_STANDARD LESS 17)
+   set(CMAKE_CXX_STANDARD 17)
+endif()
 
 include(ElementsConfigCommon)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -173,7 +173,11 @@ target_sources(elements
 
 target_include_directories(elements PUBLIC include)
 target_link_libraries(elements PUBLIC cycfi::infra)
-target_compile_features(elements PUBLIC cxx_std_20)
+if(CMAKE_CXX_STANDARD EQUAL 20)
+   target_compile_features(elements PUBLIC cxx_std_20)
+else()
+   target_compile_features(elements PUBLIC cxx_std_17)
+endif()
 
 if(ELEMENTS_ENABLE_LTO)
    set_target_properties(elements PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -173,7 +173,7 @@ target_sources(elements
 
 target_include_directories(elements PUBLIC include)
 target_link_libraries(elements PUBLIC cycfi::infra)
-target_compile_features(elements PUBLIC cxx_std_17)
+target_compile_features(elements PUBLIC cxx_std_20)
 
 if(ELEMENTS_ENABLE_LTO)
    set_target_properties(elements PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)

--- a/lib/include/elements/support/text_utils.hpp
+++ b/lib/include/elements/support/text_utils.hpp
@@ -177,6 +177,7 @@ namespace cycfi { namespace elements
    // Helper for converting char8_t[] string literals to char[]
    ////////////////////////////////////////////////////////////////////////////
 
+#if __cplusplus >= 202002L // C++20
    // see https://developercommunity.visualstudio.com/t/C20-String-literal-operator-template-u/1318552
 #ifdef __INTELLISENSE__
    consteval const char* operator""_as_char([[maybe_unused]] const char8_t*, [[maybe_unused]] std::size_t)
@@ -216,6 +217,12 @@ namespace cycfi { namespace elements
    constexpr auto& operator""_as_char()
    {
       return make_as_char_buffer<L>(std::make_index_sequence<decltype(L)::size>());
+   }
+#endif
+#else
+   constexpr const char* operator""_as_char(const char* src, std::size_t)
+   {
+      return src;
    }
 #endif
 

--- a/lib/include/elements/support/text_utils.hpp
+++ b/lib/include/elements/support/text_utils.hpp
@@ -36,8 +36,8 @@ namespace cycfi { namespace elements
          case 11:       // \v
          case 12:       // \f
          case 32:       // space
-			case 10:		   // \n
-			case 13:		   // \r
+         case 10:		   // \n
+         case 13:		   // \r
          case 0xA0:     // NBSP
             return true;
          default:
@@ -50,9 +50,9 @@ namespace cycfi { namespace elements
    {
       switch (codepoint)
       {
-			case 10:		   // \n
-			case 13:		   // \r
-			case 0x85:	   // NEL
+         case 10:		   // \n
+         case 13:		   // \r
+         case 0x85:	   // NEL
             return true;
          default:
             return false;
@@ -172,6 +172,53 @@ namespace cycfi { namespace elements
       ++utf8; // one past the last byte
       return cp;
    }
+
+   ////////////////////////////////////////////////////////////////////////////
+   // Helper for converting char8_t[] string literals to char[]
+   ////////////////////////////////////////////////////////////////////////////
+
+   // see https://developercommunity.visualstudio.com/t/C20-String-literal-operator-template-u/1318552
+#ifdef __INTELLISENSE__
+   consteval const char* operator""_as_char([[maybe_unused]] const char8_t*, [[maybe_unused]] std::size_t)
+   {
+      return "";
+   }
+#else
+   template<std::size_t N>
+   struct char8_t_string_literal
+   {
+      char8_t buffer[N];
+      static constexpr inline std::size_t size = N;
+
+      template<std::size_t... I>
+      constexpr char8_t_string_literal(const char8_t(&r)[N], std::index_sequence<I...>)
+         : buffer{ r[I]... } {}
+
+      constexpr char8_t_string_literal(const char8_t(&r)[N])
+         : char8_t_string_literal(r, std::make_index_sequence<N>()) {}
+   };
+
+   template<char8_t_string_literal L, std::size_t... I>
+   constexpr inline const char as_char_buffer[sizeof...(I)] = { static_cast<char>(L.buffer[I])... };
+
+   template<char8_t_string_literal L, std::size_t... I>
+   constexpr auto& make_as_char_buffer(std::index_sequence<I...>)
+   {
+      return as_char_buffer<L, I...>;
+   }
+
+   constexpr char operator ""_as_char(char8_t c)
+   {
+      return c;
+   }
+
+   template<char8_t_string_literal L>
+   constexpr auto& operator""_as_char()
+   {
+      return make_as_char_buffer<L>(std::make_index_sequence<decltype(L)::size>());
+   }
+#endif
+
 }}
 
 #endif

--- a/lib/src/element/gallery/menu.cpp
+++ b/lib/src/element/gallery/menu.cpp
@@ -4,6 +4,7 @@
    Distributed under the MIT License [ https://opensource.org/licenses/MIT ]
 =============================================================================*/
 #include <elements/element/gallery/menu.hpp>
+#include <elements/support/text_utils.hpp>
 
 namespace cycfi { namespace elements
 {
@@ -148,7 +149,7 @@ namespace cycfi { namespace elements
 
             default:
 #if defined(__APPLE__)
-               mod_ += u8"⇧";
+               mod_ += u8"⇧"_as_char;
 #else
                mod_ += "Shift+";
 #endif
@@ -158,11 +159,11 @@ namespace cycfi { namespace elements
 
 #if defined(__APPLE__)
       if (mod & mod_alt)
-         mod_ += u8"⌥";
+         mod_ += u8"⌥"_as_char;
       if (mod & mod_control)
-         mod_ += u8"⌃";
+         mod_ += u8"⌃"_as_char;
       if ((mod & mod_command) || (mod & mod_action))
-         mod_ += u8"⌘";
+         mod_ += u8"⌘"_as_char;
 #else
       if ((mod & mod_control) || (mod & mod_action))
          mod_ = "Ctrl+" + mod_;
@@ -170,9 +171,9 @@ namespace cycfi { namespace elements
          mod_ += "Alt+";
       if (mod & mod_super)
 #if defined(_WIN32)
-         mod_ += u8"⊞";
+         mod_ += u8"⊞"_as_char;
 #else
-         mod_ += u8"◇";
+         mod_ += u8"◇"_as_char;
 #endif
 #endif
 
@@ -184,7 +185,7 @@ namespace cycfi { namespace elements
       {
          switch (k)
          {
-            default:                         key_ += u8"�"; break;
+            default:                         key_ += u8"�"_as_char; break;
 
             case key_code::space:            key_ += ' '; break;
             case key_code::apostrophe:       key_ += '\''; break;
@@ -219,25 +220,25 @@ namespace cycfi { namespace elements
             case key_code::backslash:        key_ += '\\'; break;
             case key_code::right_bracket:    key_ += ']'; break;
             case key_code::grave_accent:     key_ += '`'; break;
-            case key_code::escape:           key_ += u8"⎋"; break;
-            case key_code::enter:            key_ += u8"⏎"; break;
-            case key_code::tab:              key_ += u8"⇥"; break;
-            case key_code::backspace:        key_ += u8"⌫"; break;
+            case key_code::escape:           key_ += u8"⎋"_as_char; break;
+            case key_code::enter:            key_ += u8"⏎"_as_char; break;
+            case key_code::tab:              key_ += u8"⇥"_as_char; break;
+            case key_code::backspace:        key_ += u8"⌫"_as_char; break;
             case key_code::insert:           break;
-            case key_code::_delete:          key_ += u8"⌫"; break;
-            case key_code::right:            key_ += u8"→"; break;
-            case key_code::left:             key_ += u8"←"; break;
-            case key_code::down:             key_ += u8"↓"; break;
-            case key_code::up:               key_ += u8"↑"; break;
-            case key_code::page_up:          key_ += u8"⇞"; break;
-            case key_code::page_down:        key_ += u8"⇟"; break;
-            case key_code::home:             key_ += u8"⇱"; break;
-            case key_code::end:              key_ += u8"⇲"; break;
-            case key_code::caps_lock:        key_ += u8"⇪"; break;
-            case key_code::scroll_lock:      key_ += u8"⤓"; break;
-            case key_code::num_lock:         key_ += u8"⇭"; break;
-            case key_code::print_screen:     key_ += u8"⎙"; break;
-            case key_code::pause:            key_ += u8"⎉"; break;
+            case key_code::_delete:          key_ += u8"⌫"_as_char; break;
+            case key_code::right:            key_ += u8"→"_as_char; break;
+            case key_code::left:             key_ += u8"←"_as_char; break;
+            case key_code::down:             key_ += u8"↓"_as_char; break;
+            case key_code::up:               key_ += u8"↑"_as_char; break;
+            case key_code::page_up:          key_ += u8"⇞"_as_char; break;
+            case key_code::page_down:        key_ += u8"⇟"_as_char; break;
+            case key_code::home:             key_ += u8"⇱"_as_char; break;
+            case key_code::end:              key_ += u8"⇲"_as_char; break;
+            case key_code::caps_lock:        key_ += u8"⇪"_as_char; break;
+            case key_code::scroll_lock:      key_ += u8"⤓"_as_char; break;
+            case key_code::num_lock:         key_ += u8"⇭"_as_char; break;
+            case key_code::print_screen:     key_ += u8"⎙"_as_char; break;
+            case key_code::pause:            key_ += u8"⎉"_as_char; break;
 
             case key_code::f1: case key_code::f2: case key_code::f3:
             case key_code::f4: case key_code::f5: case key_code::f6:
@@ -263,9 +264,9 @@ namespace cycfi { namespace elements
             case key_code::kp_multiply:      key_ += '*'; break;
             case key_code::kp_subtract:      key_ += '-'; break;
             case key_code::kp_add:           key_ += '+'; break;
-            case key_code::kp_enter:         key_ += u8"⌤"; break;
+            case key_code::kp_enter:         key_ += u8"⌤"_as_char; break;
             case key_code::kp_equal:         key_ += '='; break;
-            case key_code::menu:             key_ += u8"☰"; break;
+            case key_code::menu:             key_ += u8"☰"_as_char; break;
          }
       }
 


### PR DESCRIPTION
This PR adds as_char, which is used to fix ill-formed char8_t[] to char[] string literals in C++20, so now it's possible to compile elements in C++20.
CMAKE_CXX_STANDARD should be set to 20 to do so.
Checked on Windows.

close #239 