### PR TITLE
Update canvas transform functions

### DIFF
--- a/lib/include/elements/support/canvas.hpp
+++ b/lib/include/elements/support/canvas.hpp
@@ -48,7 +48,9 @@ namespace cycfi { namespace elements
       void              scale(point p);
       void              skew(float sx, float sy);
       point             device_to_user(point p);
+      point             device_to_user_distance(point p);
       point             user_to_device(point p);
+      point             user_to_device_distance(point p);
 
       ///////////////////////////////////////////////////////////////////////////////////
       // Paths

--- a/lib/src/support/canvas.cpp
+++ b/lib/src/support/canvas.cpp
@@ -109,11 +109,27 @@ namespace cycfi { namespace elements
    {
       double x = p.x * _pre_scale;
       double y = p.y * _pre_scale;
+      cairo_device_to_user(&_context, &x, &y);
+      return { float(x), float(y) };
+   }
+
+   point canvas::device_to_user_distance(point p)
+   {
+      double x = p.x * _pre_scale;
+      double y = p.y * _pre_scale;
       cairo_device_to_user_distance(&_context, &x, &y);
       return { float(x), float(y) };
    }
 
    point canvas::user_to_device(point p)
+   {
+      double x = p.x;
+      double y = p.y;
+      cairo_user_to_device(&_context, &x, &y);
+      return { float(x / _pre_scale), float(y / _pre_scale) };
+   }
+
+   point canvas::user_to_device_distance(point p)
    {
       double x = p.x;
       double y = p.y;


### PR DESCRIPTION
Different methods are needed for distance conversions and coordinate conversions. See [issue](https://github.com/cycfi/elements/issues/314) 

Fixed:
- canvas::device_to_user
- canvas::user_to_device

Added:
- canvas::device_to_user_distance
- canvas::user_to_device_distance