### PR TITLE
Fix bounds generation for fixed_size.

### DIFF
--- a/lib/include/elements/element/size.hpp
+++ b/lib/include/elements/element/size.hpp
@@ -63,7 +63,8 @@ namespace cycfi { namespace elements
    template <typename Subject>
    inline void size_element<Subject>::prepare_subject(context& ctx)
    {
-      auto e_limits = this->subject().limits(ctx);
+      // use the fixed width/height as computed by limits
+      auto e_limits = this->limits(ctx);
       ctx.bounds.right = ctx.bounds.left + e_limits.min.x;
       ctx.bounds.bottom = ctx.bounds.top + e_limits.min.y;
    }
@@ -120,7 +121,9 @@ namespace cycfi { namespace elements
    template <typename Subject>
    inline void hsize_element<Subject>::prepare_subject(context& ctx)
    {
-      ctx.bounds.right = ctx.bounds.left + _width;
+      // use the fixed width as computed by limits
+      auto e_limits = this->limits(ctx);
+      ctx.bounds.right = ctx.bounds.left + e_limits.min.x;
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -175,7 +178,9 @@ namespace cycfi { namespace elements
    template <typename Subject>
    inline void vsize_element<Subject>::prepare_subject(context& ctx)
    {
-      ctx.bounds.bottom = ctx.bounds.top + _height;
+      // use the fixed height as computed by limits
+      auto e_limits = this->limits(ctx);
+      ctx.bounds.bottom = ctx.bounds.top + e_limits.min.y;
    }
 
    ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Use the fixed w/h as computed by limits() as it apples clamping to ensure the fixed size doest violate the subjects natural limits

This attempts to address the issues noted in https://github.com/cycfi/elements/issues/357