### PR TITLE
Ensure dangling resources are destroyed in move-assignment operator

### DIFF
--- a/lib/include/elements/support/pixmap.hpp
+++ b/lib/include/elements/support/pixmap.hpp
@@ -97,8 +97,7 @@ namespace cycfi { namespace elements
    {
       if (this != &rhs)
       {
-         _surface = rhs._surface;
-         rhs._surface = nullptr;
+        std::swap(_surface, rhs._surface);
       }
       return *this;
    }

--- a/lib/src/support/glyphs.cpp
+++ b/lib/src/support/glyphs.cpp
@@ -181,6 +181,13 @@ namespace cycfi { namespace elements
    {
       if (&rhs != this)
       {
+         if (_glyphs)
+            cairo_glyph_free(_glyphs);
+         if (_clusters)
+            cairo_text_cluster_free(_clusters);
+         if (_scaled_font)
+            cairo_scaled_font_destroy(_scaled_font);
+      
          _first = rhs._first;
          _last = rhs._last;
          _scaled_font = rhs._scaled_font;


### PR DESCRIPTION
Fix monitor leaks in move-assignment