### PR TITLE
Allow to cancel a timed callback.

### DIFF
--- a/lib/include/elements/view.hpp
+++ b/lib/include/elements/view.hpp
@@ -102,8 +102,13 @@ namespace cycfi { namespace elements
       using io_context = asio::io_context;
       io_context&             io();
 
+      struct timer
+      {
+         std::function<void()> cancel;
+      };
+
                               template <typename T, typename F>
-      void                    post(T duration, F f);
+      timer                   post(T duration, F f);
 
                               template <typename F>
       void                    post(F f);
@@ -329,10 +334,10 @@ namespace cycfi { namespace elements
    }
 
    template <typename T, typename F>
-   inline void view::post(T duration, F f)
+   inline view::timer view::post(T duration, F f)
    {
       auto timer = std::make_shared<asio::steady_timer>(_io);
-      timer->expires_from_now(duration);
+      timer->expires_after(duration);
       timer->async_wait(
          [timer, f](auto const& err)
          {
@@ -340,6 +345,8 @@ namespace cycfi { namespace elements
                f();
          }
       );
+
+      return { [timer] { timer->cancel(); } };
    }
 
    template <typename F>

--- a/lib/include/elements/view.hpp
+++ b/lib/include/elements/view.hpp
@@ -102,13 +102,11 @@ namespace cycfi { namespace elements
       using io_context = asio::io_context;
       io_context&             io();
 
-      struct timer
-      {
-         std::function<void()> cancel;
-      };
+
+      using steady_timer_ptr = std::shared_ptr<asio::steady_timer>;
 
                               template <typename T, typename F>
-      timer                   post(T duration, F f);
+      steady_timer_ptr        post(T duration, F f);
 
                               template <typename F>
       void                    post(F f);
@@ -334,7 +332,7 @@ namespace cycfi { namespace elements
    }
 
    template <typename T, typename F>
-   inline view::timer view::post(T duration, F f)
+   inline view::steady_timer_ptr view::post(T duration, F f)
    {
       auto timer = std::make_shared<asio::steady_timer>(_io);
       timer->expires_after(duration);
@@ -346,7 +344,7 @@ namespace cycfi { namespace elements
          }
       );
 
-      return { [timer] { timer->cancel(); } };
+      return timer;
    }
 
    template <typename F>


### PR DESCRIPTION
As per our discussion in #361, I've implemented a way to cancel a timed callback posted on a view. I've used a simple wrapper that only exposes a `cancel` function.