### PR TITLE
Implemented logarithmic slider ticks

### DIFF
--- a/examples/range_slider/main.cpp
+++ b/examples/range_slider/main.cpp
@@ -57,11 +57,13 @@ auto make_range_slider(view& _view) {
 		_min_textbox.second->set_text(pretty_printer(axis_transform(value)));
         _view.refresh(_min_textbox.first);
 	};
+	_range_slider.edit_value_first(_range_slider.value_first());
 
 	_range_slider.on_change.second = [&_view, pretty_printer, axis_transform] (float value) {
 		_max_textbox.second->set_text(pretty_printer(axis_transform(value)));
         _view.refresh(_max_textbox.first);
 	};
+	_range_slider.edit_value_second(_range_slider.value_second());
 
 	_min_textbox.second->on_text = [] (std::string_view text) {
 		if (text.empty()) {
@@ -99,36 +101,47 @@ auto make_range_slider(view& _view) {
 		}
 	};
 
-	return vtile(
-		margin(
-			{50, 10, 50, 10},
-			link(_range_slider)
-		),
+	return margin(
+		{10, 10, 10, 10},
 		layer(
-			align_left(
+			vtile(
+				vspace(10),
+				align_center(
+					label("Linear range slider").font_size(18)
+				),
+				vspace(10),
 				margin(
 					{50, 10, 50, 10},
-					hsize(
-						100,
-						layer(
-							link(_min_textbox.first),
-							link(_min_bg)
+					link(_range_slider)
+				),
+				layer(
+					align_left(
+						margin(
+							{50, 10, 50, 10},
+							hsize(
+								100,
+								layer(
+									link(_min_textbox.first),
+									link(_min_bg)
+								)
+							)
+						)
+					),
+					align_right(
+						margin(
+							{50, 10, 50, 10},
+							hsize(
+								100,
+								layer(
+									link(_max_textbox.first),
+									link(_max_bg)
+								)
+							)
 						)
 					)
 				)
 			),
-			align_right(
-				margin(
-					{50, 10, 50, 10},
-					hsize(
-						100,
-						layer(
-							link(_max_textbox.first),
-							link(_max_bg)
-						)
-					)
-				)
-			)
+			frame{}
 		)
 	);
 }
@@ -170,11 +183,13 @@ auto make_log_range_slider(view& _view) {
 		_min_textbox.second->set_text(pretty_printer(axis_transform(value)));
         _view.refresh(_min_textbox.first);
 	};
+	_range_slider.edit_value_first(_range_slider.value_first());
 
 	_range_slider.on_change.second = [&_view, pretty_printer, axis_transform] (float value) {
 		_max_textbox.second->set_text(pretty_printer(axis_transform(value)));
         _view.refresh(_max_textbox.first);
 	};
+	_range_slider.edit_value_second(_range_slider.value_second());
 
 	_min_textbox.second->on_text = [] (std::string_view text) {
 		if (text.empty()) {
@@ -212,36 +227,47 @@ auto make_log_range_slider(view& _view) {
 		}
 	};
 
-	return vtile(
-		margin(
-			{50, 10, 50, 10},
-			link(_range_slider)
-		),
+	return margin(
+		{10, 10, 10, 10},
 		layer(
-			align_left(
+			vtile(
+				vspace(10),
+				align_center(
+					label("Logarithmic range slider").font_size(18)
+				),
+				vspace(10),
 				margin(
 					{50, 10, 50, 10},
-					hsize(
-						100,
-						layer(
-							link(_min_textbox.first),
-							link(_min_bg)
+					link(_range_slider)
+				),
+				layer(
+					align_left(
+						margin(
+							{50, 10, 50, 10},
+							hsize(
+								100,
+								layer(
+									link(_min_textbox.first),
+									link(_min_bg)
+								)
+							)
+						)
+					),
+					align_right(
+						margin(
+							{50, 10, 50, 10},
+							hsize(
+								100,
+								layer(
+									link(_max_textbox.first),
+									link(_max_bg)
+								)
+							)
 						)
 					)
 				)
 			),
-			align_right(
-				margin(
-					{50, 10, 50, 10},
-					hsize(
-						100,
-						layer(
-							link(_max_textbox.first),
-							link(_max_bg)
-						)
-					)
-				)
-			)
+			frame{}
 		)
 	);
 }

--- a/examples/range_slider/main.cpp
+++ b/examples/range_slider/main.cpp
@@ -138,10 +138,10 @@ auto make_log_range_slider(view& _view) {
 	double max_val = 1e0;
 	static auto track = basic_track<5, false>(colors::black);
 	static auto _range_slider = range_slider(
-		basic_thumb<5>(),
-		basic_thumb<5>(),
+		basic_thumb<10>(),
+		basic_thumb<10>(),
 		slider_labels<10>(
-			slider_marks_log<20, 4, 10>(track), 0.8, "1e-4", "1e-3", "1e-2", "1e-1", "1e0"
+			slider_marks_log<20, 4>(track), 0.8, "1e-4", "1e-3", "1e-2", "1e-1", "1e0"
 		),
 		{0.1, 0.8}
 	);

--- a/lib/include/elements/element/slider.hpp
+++ b/lib/include/elements/element/slider.hpp
@@ -365,6 +365,51 @@ namespace cycfi { namespace elements
       return {std::forward<Subject>(subject)};
    }
 
+   template <
+      std::size_t _size, std::size_t _num_divs
+    , std::size_t _major_divs, typename Subject>
+   class slider_marks_log_element : public slider_element_base<_size, Subject>
+   {
+
+   public:
+
+      static_assert(_major_divs > 0, "Major divisions must be greater than zero");
+
+      using base_type = slider_element_base<_size, Subject>;
+      using base_type::base_type;
+
+      void                    draw(context const& ctx) override;
+   };
+
+   void draw_slider_marks_log(
+      canvas& cnv, rect bounds, float size, std::size_t major_divs
+    , std::size_t minor_divs, color c);
+
+   template <
+      std::size_t _size, std::size_t _num_divs
+      , std::size_t _major_divs, typename Subject>
+   inline void
+   slider_marks_log_element<_size, _num_divs, _major_divs, Subject>
+      ::draw(context const& ctx)
+   {
+      // Draw logarithmic lines
+      draw_slider_marks_log(
+         ctx.canvas, ctx.bounds, _size, _num_divs
+         , _major_divs, colors::light_gray);
+
+      // Draw the subject
+      base_type::draw(ctx);
+   }
+
+   template <
+      std::size_t _size, std::size_t _num_divs = 50
+      , std::size_t _major_divs = 10, typename Subject>
+   inline slider_marks_log_element<_size, _num_divs, _major_divs, remove_cvref_t<Subject>>
+   slider_marks_log(Subject&& subject)
+   {
+      return {std::forward<Subject>(subject)};
+   }
+
    ////////////////////////////////////////////////////////////////////////////
    // Slider Labels (You can use this to place slider labels with sliders)
    ////////////////////////////////////////////////////////////////////////////

--- a/lib/include/elements/element/slider.hpp
+++ b/lib/include/elements/element/slider.hpp
@@ -402,9 +402,9 @@ namespace cycfi { namespace elements
    }
 
    template <
-      std::size_t _size, std::size_t _num_divs = 50
-      , std::size_t _major_divs = 10, typename Subject>
-   inline slider_marks_log_element<_size, _num_divs, _major_divs, remove_cvref_t<Subject>>
+      std::size_t _size, std::size_t _major_divs = 10
+      , std::size_t _minor_divs = 10, typename Subject>
+   inline slider_marks_log_element<_size, _major_divs, _minor_divs, remove_cvref_t<Subject>>
    slider_marks_log(Subject&& subject)
    {
       return {std::forward<Subject>(subject)};

--- a/lib/include/elements/element/slider.hpp
+++ b/lib/include/elements/element/slider.hpp
@@ -394,8 +394,8 @@ namespace cycfi { namespace elements
    {
       // Draw logarithmic lines
       draw_slider_marks_log(
-         ctx.canvas, ctx.bounds, _size, _num_divs
-         , _major_divs, colors::light_gray);
+         ctx.canvas, ctx.bounds, _size, _major_divs
+         , _minor_divs, colors::light_gray);
 
       // Draw the subject
       base_type::draw(ctx);

--- a/lib/include/elements/element/slider.hpp
+++ b/lib/include/elements/element/slider.hpp
@@ -386,10 +386,10 @@ namespace cycfi { namespace elements
     , std::size_t minor_divs, color c);
 
    template <
-      std::size_t _size, std::size_t _num_divs
-      , std::size_t _major_divs, typename Subject>
+      std::size_t _size, std::size_t _major_divs
+      , std::size_t _minor_divs, typename Subject>
    inline void
-   slider_marks_log_element<_size, _num_divs, _major_divs, Subject>
+   slider_marks_log_element<_size, _major_divs, _minor_divs, Subject>
       ::draw(context const& ctx)
    {
       // Draw logarithmic lines

--- a/lib/src/element/slider.cpp
+++ b/lib/src/element/slider.cpp
@@ -258,18 +258,10 @@ namespace cycfi { namespace elements
       float xmax = vertical? bounds.bottom : bounds.right;
       float major_step = (xmax-xmin)/major_divs;
 
-      double x1 = 0;
-      double x2 = 1;
-      double y1 = 1;
-      double y2 = 10;
-      auto f = [x1, x2, y1, y2] (float y) {
-         return (std::log(y) - std::log(y1)) / (std::log(y2) - std::log(y1)) * (x2 - x1) + x1;
-      };
-
       std::vector<float> minor_offsets(minor_divs);
       for (std::size_t i = 1; i != minor_divs; ++i)
       {
-         minor_offsets[i-1] = f(i)*major_step;
+         minor_offsets[i-1] = std::log10(i)*major_step;
       }
 
       for (std::size_t i = 0; i != major_divs+1; ++i) 

--- a/lib/src/element/slider.cpp
+++ b/lib/src/element/slider.cpp
@@ -8,6 +8,7 @@
 #include <elements/view.hpp>
 #include <cmath>
 
+#include <iostream>
 namespace cycfi { namespace elements
 {
    view_limits slider_base::limits(basic_context const& ctx) const
@@ -239,6 +240,75 @@ namespace cycfi { namespace elements
          }
          cnv.stroke();
          pos += incr;
+      }
+   }
+
+   void draw_slider_marks_log(
+      canvas& cnv, rect bounds, float size, std::size_t major_divs
+    , std::size_t minor_divs, color c)
+   {
+      auto w = bounds.width();
+      auto h = bounds.height();
+      auto state = cnv.new_state();
+      auto const& theme = get_theme();
+
+      float inset = size / 6;
+      bool vertical = w < h;
+      float xmin = vertical? bounds.top : bounds.left;
+      float xmax = vertical? bounds.bottom : bounds.right;
+      float major_step = (xmax-xmin)/major_divs;
+
+      double x1 = 0;
+      double x2 = 1;
+      double y1 = 1;
+      double y2 = 10;
+      auto f = [x1, x2, y1, y2] (float y) {
+         return (std::log(y) - std::log(y1)) / (std::log(y2) - std::log(y1)) * (x2 - x1) + x1;
+      };
+
+      std::vector<float> minor_offsets(minor_divs);
+      for (std::size_t i = 1; i != minor_divs; ++i)
+      {
+         minor_offsets[i-1] = f(i)*major_step;
+      }
+
+      for (std::size_t i = 0; i != major_divs+1; ++i) 
+      {
+         float pos = xmin + i*major_step;
+
+         cnv.line_width(theme.major_ticks_width);
+         cnv.stroke_style(c.level(theme.major_ticks_level));
+         if (vertical)
+         {
+            cnv.move_to({bounds.left, pos});
+            cnv.line_to({bounds.right, pos});
+         }
+         else
+         {
+            cnv.move_to({pos, bounds.top});
+            cnv.line_to({pos, bounds.bottom});
+         }
+         cnv.stroke();
+
+         if (i == major_divs) {break;}
+         for (std::size_t j = 1; j != minor_divs; ++j)
+         {
+            float minor_pos = pos + minor_offsets[j-1];
+
+            cnv.line_width(theme.minor_ticks_width);
+            cnv.stroke_style(c.level(theme.minor_ticks_level));
+            if (vertical)
+            {
+               cnv.move_to({bounds.left + inset, minor_pos});
+               cnv.line_to({bounds.right - inset, minor_pos});
+            }
+            else
+            {
+               cnv.move_to({minor_pos, bounds.top + inset});
+               cnv.line_to({minor_pos, bounds.bottom - inset});
+            }
+            cnv.stroke();
+         }
       }
    }
 


### PR DESCRIPTION
I implemented a new element `slider_marks_log` and showcase it in the `range_slider` example. 

I couldn't figure out how to do this correctly while limiting myself to the original `<size, num_divs, major_divs>` template, so I switched it around (for this element only) to `<size, major_divs, minor_divs>` instead. For consistency I think either the normal `slider_marks` element should also be updated with this, or alternatively remove the `minor_divs` template from this new element and hardcode it to `10`. I don't see any reason to use a different number than this anyway. 