### PR TITLE
Consistent horizontal scrolling

### DIFF
--- a/lib/src/element/slider.cpp
+++ b/lib/src/element/slider.cpp
@@ -66,7 +66,7 @@ namespace cycfi { namespace elements
    bool slider_base::scroll(context const& ctx, point dir, point p)
    {
       auto sdir = scroll_direction();
-      double new_value = value() + (_is_horiz ? dir.x * sdir.x : dir.y * -sdir.y) * 0.005;
+      double new_value = value() + (_is_horiz ? dir.x*sdir.x + !dir.x*dir.y*-sdir.y : dir.y * -sdir.y) * 0.005;
       clamp(new_value, 0.0, 1.0);
       track_scroll(ctx, dir, p);
       edit_value(new_value);


### PR DESCRIPTION
I added the possibility of using a vertical scroll wheel to move a horizontal slider in my `range_slider` implementation. This brings this same feature to the 'normal' `slider`. 