### PR TITLE
Range slider updates

### DIFF
--- a/examples/basic_sliders_and_knobs/main.cpp
+++ b/examples/basic_sliders_and_knobs/main.cpp
@@ -24,7 +24,7 @@ auto make_markers()
 {
    auto track = basic_track<5, is_vertical>();
    return slider_labels<10>(
-      slider_marks<40>(track),         // Track with marks
+      slider_marks_lin<40>(track),     // Track with marks
       0.8,                             // Label font size (relative size)
       "0", "1", "2", "3", "4",         // Labels
       "5", "6", "7", "8", "9", "10"

--- a/examples/range_slider/main.cpp
+++ b/examples/range_slider/main.cpp
@@ -285,11 +285,11 @@ auto make_overlapping_range_slider(view& _view) {
 	static auto _range_slider = range_slider(
 		fixed_size(
 			{5, 30},
-			box(colors::light_gray)
+			box(colors::lime_green)
 		),
         fixed_size(
 			{5, 30},
-			box(colors::light_gray)
+			box(colors::orange_red)
 		),
 		slider_labels<11>(
 			slider_marks_lin<20, 5, 10>(track), 0.8, "0", "2", "4", "6", "8", "10"

--- a/examples/range_slider/main.cpp
+++ b/examples/range_slider/main.cpp
@@ -297,7 +297,7 @@ auto make_overlapping_range_slider(view& _view) {
 		{0.1, 0.8},
 		+0.5 // overlap parameter - +0.5 means total overlap, 0 means exactly no overlap, -0.5 means negative overlap (e.g. forcing some minimum separation)
 	);
-	return make_range_slider(_view, _range_slider, "Overlapping linear range slider");
+	return make_range_slider(_view, _range_slider, "Overlapping linear range slider. Alt-click to switch active thumb.");
 }
 
 int main(int argc, char* argv[])

--- a/examples/range_slider/main.cpp
+++ b/examples/range_slider/main.cpp
@@ -269,7 +269,7 @@ auto make_default_range_slider(view& _view) {
 			box(colors::light_gray)
 		),
 		slider_labels<11>(
-			slider_marks<20, 10*5, 10>(track), 0.8, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
+			slider_marks_lin<20, 10, 5>(track), 0.8, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
 		),
 		{0.1, 0.8}
 	);
@@ -292,7 +292,7 @@ auto make_overlapping_range_slider(view& _view) {
 			box(colors::light_gray)
 		),
 		slider_labels<11>(
-			slider_marks<20, 10*5, 10>(track), 0.8, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
+			slider_marks_lin<20, 5, 10>(track), 0.8, "0", "2", "4", "6", "8", "10"
 		),
 		{0.1, 0.8},
 		+0.5 // overlap parameter - +0.5 means total overlap, 0 means exactly no overlap, -0.5 means negative overlap (e.g. forcing some minimum separation)

--- a/examples/sprite_sliders_and_knobs/main.cpp
+++ b/examples/sprite_sliders_and_knobs/main.cpp
@@ -23,7 +23,7 @@ auto make_markers()
 {
    auto track = basic_track<5, is_vertical>();
    return slider_labels<10>(
-      slider_marks<40>(track),         // Track with marks
+      slider_marks_lin<40>(track),     // Track with marks
       0.8,                             // Label font size (relative size)
       "0", "1", "2", "3", "4",         // Labels
       "5", "6", "7", "8", "9", "10"

--- a/lib/include/elements/element/range_slider.hpp
+++ b/lib/include/elements/element/range_slider.hpp
@@ -23,7 +23,14 @@ namespace cycfi { namespace elements
       using val_type = std::pair<double, double>;
       using element_cref_pair_type = std::pair<std::reference_wrapper<element const>, std::reference_wrapper<element const>>;
       using element_ref_pair_type = std::pair<std::reference_wrapper<element>, std::reference_wrapper<element>>;
-      enum class state { idle, moving_thumb1, moving_thumb2, scrolling_thumb1, scrolling_thumb2 };
+      enum class state { 
+         idle_1, // idle, last moved thumb 1
+         idle_2, // idle, last moved thumb 2
+         moving_thumb1, 
+         moving_thumb2, 
+         scrolling_thumb1, 
+         scrolling_thumb2
+      };
    public:
 
                               range_slider_base(std::pair<double, double> init_value)
@@ -61,9 +68,14 @@ namespace cycfi { namespace elements
       virtual element&               track() = 0;
 
    private:
-      state                          _state = state::idle;
+      state                          _state = state::idle_1;
       std::pair<double, double>      _value;
       mutable bool                   _is_horiz = false;
+
+      void                           move_first(context const& ctx, tracker_info& track_info);
+      void                           move_second(context const& ctx, tracker_info& track_info);
+      void                           move_both_from_first(context const& ctx, tracker_info& track_info);
+      void                           move_both_from_second(context const& ctx, tracker_info& track_info);
    };
 
    inline void range_slider_base::edit(view& view_, std::pair<double, double> val)

--- a/lib/include/elements/element/slider.hpp
+++ b/lib/include/elements/element/slider.hpp
@@ -321,6 +321,10 @@ namespace cycfi { namespace elements
    ////////////////////////////////////////////////////////////////////////////
    // Slider Marks (You can use this to place tick marks on slider)
    ////////////////////////////////////////////////////////////////////////////
+
+   ////////////////////////////////////////////////////////////////////////////
+   // deprecated 
+   ////////////////////////////////////////////////////////////////////////////
    template <
       std::size_t _size, std::size_t _num_divs
     , std::size_t _major_divs, typename Subject>
@@ -359,15 +363,61 @@ namespace cycfi { namespace elements
    template <
       std::size_t _size, std::size_t _num_divs = 50
     , std::size_t _major_divs = 10, typename Subject>
+   [[deprecated("Use slider_marks_lin instead")]] 
    inline slider_marks_element<_size, _num_divs, _major_divs, remove_cvref_t<Subject>>
    slider_marks(Subject&& subject)
    {
       return {std::forward<Subject>(subject)};
    }
+   ////////////////////////////////////////////////////////////////////////////
 
    template <
-      std::size_t _size, std::size_t _num_divs
-    , std::size_t _major_divs, typename Subject>
+      std::size_t _size, std::size_t _major_divs
+    , std::size_t _minor_divs, typename Subject>
+   class slider_marks_lin_element : public slider_element_base<_size, Subject>
+   {
+   public:
+
+      static_assert(_major_divs > 0, "Major divisions must be greater than zero");
+
+      using base_type = slider_element_base<_size, Subject>;
+      using base_type::base_type;
+
+      void                    draw(context const& ctx) override;
+   };
+
+   void draw_slider_marks_lin(
+      canvas& cnv, rect bounds, float size, std::size_t major_divs
+    , std::size_t minor_divs, color c);
+
+   template <
+      std::size_t _size, std::size_t _major_divs
+    , std::size_t _minor_divs, typename Subject>
+   inline void
+   slider_marks_lin_element<_size, _major_divs, _minor_divs, Subject>
+      ::draw(context const& ctx)
+   {
+      // Draw linear lines
+      draw_slider_marks_lin(
+         ctx.canvas, ctx.bounds, _size, _major_divs
+       , _minor_divs, colors::light_gray);
+
+      // Draw the subject
+      base_type::draw(ctx);
+   }
+
+   template <
+      std::size_t _size, std::size_t _major_divs
+    , std::size_t _minor_divs = 5, typename Subject>
+   inline slider_marks_lin_element<_size, _major_divs, _minor_divs, remove_cvref_t<Subject>>
+   slider_marks_lin(Subject&& subject)
+   {
+      return {std::forward<Subject>(subject)};
+   }
+
+   template <
+      std::size_t _size, std::size_t _major_divs
+    , std::size_t _minor_divs, typename Subject>
    class slider_marks_log_element : public slider_element_base<_size, Subject>
    {
 

--- a/lib/include/elements/element/slider.hpp
+++ b/lib/include/elements/element/slider.hpp
@@ -407,7 +407,7 @@ namespace cycfi { namespace elements
    }
 
    template <
-      std::size_t _size, std::size_t _major_divs
+      std::size_t _size, std::size_t _major_divs = 10
     , std::size_t _minor_divs = 5, typename Subject>
    inline slider_marks_lin_element<_size, _major_divs, _minor_divs, remove_cvref_t<Subject>>
    slider_marks_lin(Subject&& subject)
@@ -452,7 +452,7 @@ namespace cycfi { namespace elements
    }
 
    template <
-      std::size_t _size, std::size_t _major_divs = 10
+      std::size_t _size, std::size_t _major_divs = 5
       , std::size_t _minor_divs = 10, typename Subject>
    inline slider_marks_log_element<_size, _major_divs, _minor_divs, remove_cvref_t<Subject>>
    slider_marks_log(Subject&& subject)

--- a/lib/src/element/slider.cpp
+++ b/lib/src/element/slider.cpp
@@ -320,7 +320,7 @@ namespace cycfi { namespace elements
          minor_offsets[i-1] = std::log10(i)*major_step;
       }
 
-      for (std::size_t i = 0; i != major_divs; ++i) 
+      for (std::size_t i = 0; i != major_divs+1; ++i) 
       {
          float pos = xmin + i*major_step;
 

--- a/lib/src/element/slider.cpp
+++ b/lib/src/element/slider.cpp
@@ -243,6 +243,62 @@ namespace cycfi { namespace elements
       }
    }
 
+   void draw_slider_marks_lin(
+      canvas& cnv, rect bounds, float size, std::size_t major_divs
+    , std::size_t minor_divs, color c)
+   {
+      auto w = bounds.width();
+      auto h = bounds.height();
+      auto state = cnv.new_state();
+      auto const& theme = get_theme();
+
+      float inset = size / 6;
+      bool vertical = w < h;
+      float xmin = vertical? bounds.top : bounds.left;
+      float xmax = vertical? bounds.bottom : bounds.right;
+      float major_step = (xmax-xmin)/major_divs;
+      float minor_step = major_step/minor_divs;
+
+      for (std::size_t i = 0; i != major_divs+1; ++i) 
+      {
+         float pos = xmin + i*major_step;
+
+         cnv.line_width(theme.major_ticks_width);
+         cnv.stroke_style(c.level(theme.major_ticks_level));
+         if (vertical)
+         {
+            cnv.move_to({bounds.left, pos});
+            cnv.line_to({bounds.right, pos});
+         }
+         else
+         {
+            cnv.move_to({pos, bounds.top});
+            cnv.line_to({pos, bounds.bottom});
+         }
+         cnv.stroke();
+
+         if (i == major_divs) {break;}
+         cnv.line_width(theme.minor_ticks_width);
+         cnv.stroke_style(c.level(theme.minor_ticks_level));
+         for (std::size_t j = 1; j != minor_divs; ++j)
+         {
+            float minor_pos = pos + j*minor_step;
+
+            if (vertical)
+            {
+               cnv.move_to({bounds.left + inset, minor_pos});
+               cnv.line_to({bounds.right - inset, minor_pos});
+            }
+            else
+            {
+               cnv.move_to({minor_pos, bounds.top + inset});
+               cnv.line_to({minor_pos, bounds.bottom - inset});
+            }
+            cnv.stroke();
+         }
+      }
+   }
+
    void draw_slider_marks_log(
       canvas& cnv, rect bounds, float size, std::size_t major_divs
     , std::size_t minor_divs, color c)
@@ -264,7 +320,7 @@ namespace cycfi { namespace elements
          minor_offsets[i-1] = std::log10(i)*major_step;
       }
 
-      for (std::size_t i = 0; i != major_divs+1; ++i) 
+      for (std::size_t i = 0; i != major_divs; ++i) 
       {
          float pos = xmin + i*major_step;
 
@@ -283,12 +339,11 @@ namespace cycfi { namespace elements
          cnv.stroke();
 
          if (i == major_divs) {break;}
+         cnv.line_width(theme.minor_ticks_width);
+         cnv.stroke_style(c.level(theme.minor_ticks_level));
          for (std::size_t j = 1; j != minor_divs; ++j)
          {
             float minor_pos = pos + minor_offsets[j-1];
-
-            cnv.line_width(theme.minor_ticks_width);
-            cnv.stroke_style(c.level(theme.minor_ticks_level));
             if (vertical)
             {
                cnv.move_to({bounds.left + inset, minor_pos});


### PR DESCRIPTION
Second round of updates for the `range_slider`.

The following have been implemented:
- `slider_marks_lin` using the template arguments `<size, major_divs, minor_divs`.
- `slider_marks` are now deprecated, and all examples using it have been updated to instead use `slider_marks_lin`
- `range_slider` now supports the `shift` and `alt` key modifiers. 
    - The `draw` function now keeps track of which thumb is active, drawing the active on top. I have updated the `RangeSlider` example to showcase this. 
    - `shift` moves both thumbs, keeping their relative positions fixed. If either thumb collides with the track bounds, movement is blocked. This can be used mid-movement. Note: scrolling does not support this, since it doesn't have the `tracker_info` arg. 
    - `alt` always switches the active thumb, even if no thumb was targeted with the click. Thus one can either hold the key while targetting overlapping thumbs to pick the hidden one, or one can just click anywhere to visually change the active thumb. 