### PR TITLE
Allow any host UI library type

### DIFF
--- a/lib/include/elements/base_view.hpp
+++ b/lib/include/elements/base_view.hpp
@@ -291,16 +291,14 @@ namespace cycfi { namespace elements
    // The base view base class
    ////////////////////////////////////////////////////////////////////////////
 
-#if defined(ELEMENTS_HOST_UI_LIBRARY_COCOA) || defined(ELEMENTS_HOST_UI_LIBRARY_GTK)
+#if defined(ELEMENTS_HOST_UI_LIBRARY_WIN32)
+   using host_view_handle = HWND;
+   using host_window_handle = HWND;
+#else
    struct host_view;
    using host_view_handle = host_view*;
    struct host_window;
    using host_window_handle = host_window*;
-#elif defined(ELEMENTS_HOST_UI_LIBRARY_WIN32)
-   using host_view_handle = HWND;
-   using host_window_handle = HWND;
-#else
-   #error no ELEMENTS_HOST_UI_LIBRARY_* set
 #endif
 
    class base_view : non_copyable


### PR DESCRIPTION
Use HWND as view and window type on Windows, opaque structs everywhere else.
This allows to create custom implementations without having to change Elements source code