### PR TITLE
Added default scale parameter when creating an image from an image_ptr

### DIFF
--- a/lib/include/elements/element/image.hpp
+++ b/lib/include/elements/element/image.hpp
@@ -23,7 +23,7 @@ namespace cycfi { namespace elements
    {
    public:
                               image(fs::path const& path, float scale = 1);
-                              image(image_ptr pixmap_);
+                              image(image_ptr pixmap_, float scale = 1);
 
       virtual point           size() const;
       float                   scale() const { return _scale; }

--- a/lib/src/element/image.cpp
+++ b/lib/src/element/image.cpp
@@ -21,8 +21,9 @@ namespace cycfi { namespace elements
          throw std::runtime_error{"Error: Invalid image."};
    }
 
-   image::image(image_ptr pixmap_)
+   image::image(image_ptr pixmap_, float scale)
     : _pixmap(pixmap_)
+    , _scale(scale)
    {
       if (!_pixmap->impl())
          throw std::runtime_error{"Error: Invalid image."};


### PR DESCRIPTION
Without this, the rendering is incorrect because the scale variable is not initialized.