### PR TITLE
CMake version & RangeSlider cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 #  Distributed under the MIT License (https://opensource.org/licenses/MIT)
 ###############################################################################
-cmake_minimum_required(VERSION 3.9.6...3.15.0)
+cmake_minimum_required(VERSION 3.15.0)
 
 project(elements LANGUAGES C CXX)
 

--- a/examples/range_slider/main.cpp
+++ b/examples/range_slider/main.cpp
@@ -62,6 +62,7 @@ auto make_range_slider = [] (view& _view, auto _range_slider, std::string _title
         } catch (std::exception&) {
             *_min_bg = bred;
         }
+        _view.refresh(*_min_bg);
         return true;
     };
 
@@ -81,6 +82,7 @@ auto make_range_slider = [] (view& _view, auto _range_slider, std::string _title
         } catch (std::exception&) {
             *_max_bg = bred;
         }
+        _view.refresh(*_max_bg);
         return true;
     };
 
@@ -192,6 +194,7 @@ auto make_log_range_slider(view& _view) {
         } catch (std::exception&) {
             *_min_bg = bred;
         }
+        _view.refresh(*_min_bg);
         return true;
     };
 
@@ -211,6 +214,7 @@ auto make_log_range_slider(view& _view) {
         } catch (std::exception&) {
             *_max_bg = bred;
         }
+        _view.refresh(*_max_bg);
         return true;
     };
 
@@ -298,6 +302,15 @@ auto make_overlapping_range_slider(view& _view) {
     return make_range_slider(_view, _range_slider, "Overlapping linear range slider. Alt/Option-click to switch active thumb.");
 }
 
+auto make_tip_box() {
+    return margin(
+        {10, 10, 10, 10},
+        align_center(
+            label("Tip: Take a look at the Model example to see how to add validation logic to the input boxes.").font_size(16)
+        )
+    );
+}
+
 int main(int argc, char* argv[])
 {
     app _app("RangeSlider");
@@ -310,7 +323,8 @@ int main(int argc, char* argv[])
         vtile(
             make_default_range_slider(_view),
             make_overlapping_range_slider(_view),
-            make_log_range_slider(_view)
+            make_log_range_slider(_view),
+            make_tip_box()
         ),
         background
     );

--- a/examples/range_slider/main.cpp
+++ b/examples/range_slider/main.cpp
@@ -8,16 +8,16 @@
 using namespace cycfi::elements;
 
 // Main window background color
-auto constexpr bg_color_accent = rgba(55, 55, 57, 255);
-auto constexpr bg_color = rgba(35, 35, 37, 255);
-auto constexpr bred     = colors::red.level(0.7).opacity(0.4);
-auto background = box(bg_color);
+auto constexpr bg_color_accent  = rgba(55, 55, 57, 255);
+auto constexpr bg_color         = rgba(35, 35, 37, 255);
+auto constexpr bred             = colors::red.level(0.7).opacity(0.4);
+auto background                 = box(bg_color);
 
-auto make_range_slider = [] (view& _view, auto& _range_slider, std::string _title) {
-    static auto _min_textbox = input_box("min level");
-    static auto _max_textbox = input_box("max level");
-    static auto _min_bg = box(bg_color);
-    static auto _max_bg = box(bg_color);
+auto make_range_slider = [] (view& _view, auto _range_slider, std::string _title) {
+    auto _min_textbox = share(input_box("min level"));
+    auto _max_textbox = share(input_box("max level"));
+    auto _min_bg = share(box(bg_color));
+    auto _max_bg = share(box(bg_color));
 
     auto pretty_printer = [] (float value) {
         std::stringstream ss;
@@ -34,52 +34,52 @@ auto make_range_slider = [] (view& _view, auto& _range_slider, std::string _titl
     };
 
     // note: ok to take a reference to _range_slider here, since we declared it static
-    _range_slider.on_change.first = [&_view, &_range_slider, pretty_printer, axis_transform] (float value) {
-        _min_textbox.second->set_text(pretty_printer(axis_transform(value)));
-        _view.refresh(_min_textbox.first);
+    _range_slider->on_change.first = [&_view, _range_slider, _min_textbox, pretty_printer, axis_transform] (float value) {
+        _min_textbox->second->set_text(pretty_printer(axis_transform(value)));
+        _view.refresh(_min_textbox->first);
     };
-    _range_slider.edit_value_first(_range_slider.value_first());
+    _range_slider->edit_value_first(_range_slider->value_first());
 
-    _range_slider.on_change.second = [&_view, &_range_slider, pretty_printer, axis_transform] (float value) {
-        _max_textbox.second->set_text(pretty_printer(axis_transform(value)));
-        _view.refresh(_max_textbox.first);
+    _range_slider->on_change.second = [&_view, &_range_slider, _max_textbox, pretty_printer, axis_transform] (float value) {
+        _max_textbox->second->set_text(pretty_printer(axis_transform(value)));
+        _view.refresh(_max_textbox->first);
     };
-    _range_slider.edit_value_second(_range_slider.value_second());
+    _range_slider->edit_value_second(_range_slider->value_second());
 
-    _min_textbox.second->on_text = [] (std::string_view text) {
+    _min_textbox->second->on_text = [_min_bg] (std::string_view text) {
         if (text.empty()) {
-            _min_bg = bg_color;
+            *_min_bg = bg_color;
         } else {
-            _min_bg = bg_color_accent;
+            *_min_bg = bg_color_accent;
         }
     };
 
-    _min_textbox.second->on_enter = [&_view, &_range_slider, axis_transform_inv] (std::string_view text)->bool {
+    _min_textbox->second->on_enter = [&_view, _range_slider, _min_bg, axis_transform_inv] (std::string_view text)->bool {
         try {
-            _range_slider.value_first(axis_transform_inv(std::stof(std::string(text))));
-            _min_bg = bg_color;
-            _view.refresh(_range_slider);
+            _range_slider->value_first(axis_transform_inv(std::stof(std::string(text))));
+            *_min_bg = bg_color;
+            _view.refresh(*_range_slider);
         } catch (std::exception&) {
-            _min_bg = bred;
+            *_min_bg = bred;
         }
         return true;
     };
 
-    _max_textbox.second->on_text = [] (std::string_view text) {
+    _max_textbox->second->on_text = [_max_bg] (std::string_view text) {
         if (text.empty()) {
-            _max_bg = bg_color;
+            *_max_bg = bg_color;
         } else {
-            _max_bg = bg_color_accent;
+            *_max_bg = bg_color_accent;
         }
     };
 
-    _max_textbox.second->on_enter = [&_view, &_range_slider, axis_transform_inv] (std::string_view text)->bool {
+    _max_textbox->second->on_enter = [&_view, _range_slider, _max_bg, axis_transform_inv] (std::string_view text)->bool {
         try {
-            _range_slider.value_second(axis_transform_inv(std::stof(std::string(text))));
-            _max_bg = bg_color;
-            _view.refresh(_range_slider);
+            _range_slider->value_second(axis_transform_inv(std::stof(std::string(text))));
+            *_max_bg = bg_color;
+            _view.refresh(*_range_slider);
         } catch (std::exception&) {
-            _max_bg = bred;
+            *_max_bg = bred;
         }
         return true;
     };
@@ -95,7 +95,7 @@ auto make_range_slider = [] (view& _view, auto& _range_slider, std::string _titl
                 vspace(10),
                 margin(
                     {50, 10, 50, 10},
-                    link(_range_slider)
+                    hold(_range_slider)
                 ),
                 layer(
                     align_left(
@@ -104,8 +104,8 @@ auto make_range_slider = [] (view& _view, auto& _range_slider, std::string _titl
                             hsize(
                                 100,
                                 layer(
-                                    link(_min_textbox.first),
-                                    link(_min_bg)
+                                    link(_min_textbox->first),
+                                    hold(_min_bg)
                                 )
                             )
                         )
@@ -116,8 +116,8 @@ auto make_range_slider = [] (view& _view, auto& _range_slider, std::string _titl
                             hsize(
                                 100,
                                 layer(
-                                    link(_max_textbox.first),
-                                    link(_max_bg)
+                                    link(_max_textbox->first),
+                                    hold(_max_bg)
                                 )
                             )
                         )
@@ -132,8 +132,8 @@ auto make_range_slider = [] (view& _view, auto& _range_slider, std::string _titl
 auto make_log_range_slider(view& _view) {
     double min_val = 1e-4;
     double max_val = 1e0;
-    static auto track = basic_track<5, false>(colors::black);
-    static auto _range_slider = range_slider(
+    auto track = basic_track<5, false>(colors::black);
+    auto _range_slider = share(range_slider(
         basic_thumb<20>(),
         basic_thumb<20>(),
         slider_labels<10>(
@@ -141,12 +141,12 @@ auto make_log_range_slider(view& _view) {
         ),
         {0.1, 0.8},
         +0.5 // overlap parameter - +0.5 means total overlap, 0 means exactly no overlap, -0.5 means negative overlap (e.g. forcing some minimum separation)
-    );
+    ));
 
-    static auto _min_textbox = input_box("min level");
-    static auto _max_textbox = input_box("max level");
-    static auto _min_bg = box(bg_color);
-    static auto _max_bg = box(bg_color);
+    auto _min_textbox = share(input_box("min level"));
+    auto _max_textbox = share(input_box("max level"));
+    auto _min_bg = share(box(bg_color));
+    auto _max_bg = share(box(bg_color));
 
     auto pretty_printer = [] (float value) {
         std::stringstream ss;
@@ -163,53 +163,53 @@ auto make_log_range_slider(view& _view) {
         return std::pow(10, logy);
     };
 
-    _range_slider.on_change.first = [&_view, pretty_printer, axis_transform] (float value) {
-        _min_textbox.second->set_text(pretty_printer(axis_transform(value)));
-        _view.refresh(_min_textbox.first);
+    _range_slider->on_change.first = [&_view, _min_textbox, pretty_printer, axis_transform] (float value) {
+        _min_textbox->second->set_text(pretty_printer(axis_transform(value)));
+        _view.refresh(_min_textbox->first);
     };
-    _range_slider.edit_value_first(_range_slider.value_first());
+    _range_slider->edit_value_first(_range_slider->value_first());
 
-    _range_slider.on_change.second = [&_view, pretty_printer, axis_transform] (float value) {
-        _max_textbox.second->set_text(pretty_printer(axis_transform(value)));
-        _view.refresh(_max_textbox.first);
+    _range_slider->on_change.second = [&_view, _max_textbox, pretty_printer, axis_transform] (float value) {
+        _max_textbox->second->set_text(pretty_printer(axis_transform(value)));
+        _view.refresh(_max_textbox->first);
     };
-    _range_slider.edit_value_second(_range_slider.value_second());
+    _range_slider->edit_value_second(_range_slider->value_second());
 
-    _min_textbox.second->on_text = [] (std::string_view text) {
+    _min_textbox->second->on_text = [_min_bg] (std::string_view text) {
         if (text.empty()) {
-            _min_bg = bg_color;
+            *_min_bg = bg_color;
         } else {
-            _min_bg = bg_color_accent;
+            *_min_bg = bg_color_accent;
         }
     };
 
-    _min_textbox.second->on_enter = [&_view, axis_transform_inv] (std::string_view text)->bool
+    _min_textbox->second->on_enter = [&_view, _range_slider, _min_bg, axis_transform_inv] (std::string_view text)->bool
     {
         try {
-            _range_slider.value_first(axis_transform_inv(std::stof(std::string(text))));
-            _min_bg = bg_color;
-            _view.refresh(_range_slider);
+            _range_slider->value_first(axis_transform_inv(std::stof(std::string(text))));
+            *_min_bg = bg_color;
+            _view.refresh(*_range_slider);
         } catch (std::exception&) {
-            _min_bg = bred;
+            *_min_bg = bred;
         }
         return true;
     };
 
-    _max_textbox.second->on_text = [] (std::string_view text) {
+    _max_textbox->second->on_text = [_max_bg] (std::string_view text) {
         if (text.empty()) {
-            _max_bg = bg_color;
+            *_max_bg = bg_color;
         } else {
-            _max_bg = bg_color_accent;
+            *_max_bg = bg_color_accent;
         }
     };
 
-    _max_textbox.second->on_enter = [&_view, axis_transform_inv] (std::string_view text)->bool {
+    _max_textbox->second->on_enter = [&_view, _range_slider, _max_bg, axis_transform_inv] (std::string_view text)->bool {
         try {
-            _range_slider.value_second(axis_transform_inv(std::stof(std::string(text))));
-            _max_bg = bg_color;
-            _view.refresh(_range_slider);
+            _range_slider->value_second(axis_transform_inv(std::stof(std::string(text))));
+            *_max_bg = bg_color;
+            _view.refresh(*_range_slider);
         } catch (std::exception&) {
-            _max_bg = bred;
+            *_max_bg = bred;
         }
         return true;
     };
@@ -225,7 +225,7 @@ auto make_log_range_slider(view& _view) {
                 vspace(10),
                 margin(
                     {50, 10, 50, 10},
-                    link(_range_slider)
+                    hold(_range_slider)
                 ),
                 layer(
                     align_left(
@@ -234,8 +234,8 @@ auto make_log_range_slider(view& _view) {
                             hsize(
                                 100,
                                 layer(
-                                    link(_min_textbox.first),
-                                    link(_min_bg)
+                                    link(_min_textbox->first),
+                                    hold(_min_bg)
                                 )
                             )
                         )
@@ -246,8 +246,8 @@ auto make_log_range_slider(view& _view) {
                             hsize(
                                 100,
                                 layer(
-                                    link(_max_textbox.first),
-                                    link(_max_bg)
+                                    link(_max_textbox->first),
+                                    hold(_max_bg)
                                 )
                             )
                         )
@@ -260,8 +260,8 @@ auto make_log_range_slider(view& _view) {
 }
 
 auto make_default_range_slider(view& _view) {
-    static auto track = basic_track<5, false>(colors::black);
-    static auto _range_slider = range_slider(
+    auto track = basic_track<5, false>(colors::black);
+    auto _range_slider = share(range_slider(
         fixed_size(
             {8, 27},
             rbox(colors::light_gray, 2)
@@ -274,13 +274,13 @@ auto make_default_range_slider(view& _view) {
             slider_marks_lin<20, 10, 5>(track), 0.8, "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
         ),
         {0.1, 0.8}
-    );
+    ));
     return make_range_slider(_view, _range_slider, "Default linear range slider");
 }
 
 auto make_overlapping_range_slider(view& _view) {
-    static auto track = basic_track<5, false>(colors::black);
-    static auto _range_slider = range_slider(
+    auto track = basic_track<5, false>(colors::black);
+    auto _range_slider = share(range_slider(
         fixed_size(
             {8, 27},
             rbox(colors::lime_green.level(0.8), 2)
@@ -294,28 +294,28 @@ auto make_overlapping_range_slider(view& _view) {
         ),
         {0.1, 0.8},
         +0.5 // overlap parameter - +0.5 means total overlap, 0 means exactly no overlap, -0.5 means negative overlap (e.g. forcing some minimum separation)
-    );
+    ));
     return make_range_slider(_view, _range_slider, "Overlapping linear range slider. Alt/Option-click to switch active thumb.");
 }
 
 int main(int argc, char* argv[])
 {
-   app _app("RangeSlider");
-   window _win(_app.name());
-   _win.on_close = [&_app]() { _app.stop(); };
+    app _app("RangeSlider");
+    window _win(_app.name());
+    _win.on_close = [&_app]() { _app.stop(); };
 
-   view _view(_win);
+    view _view(_win);
 
-   _view.content(
-      vtile(
-        make_default_range_slider(_view),
-        make_overlapping_range_slider(_view),
-        make_log_range_slider(_view)
-      ),
-      background
-   );
+    _view.content(
+        vtile(
+            make_default_range_slider(_view),
+            make_overlapping_range_slider(_view),
+            make_log_range_slider(_view)
+        ),
+        background
+    );
 
-   _app.run();
-   return 0;
+    _app.run();
+    return 0;
 }
 


### PR DESCRIPTION
I bumped the CMake version to 3.15 as agreed in the Discord. 

I also refactored the RangeSlider example to use smart pointers instead of static elements, and added a tip directing people to check out the Model example to see how to do more advanced input validation.