### PR TITLE
Allow compiling with empty CMAKE_CXX_FLAGS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -198,7 +198,7 @@ target_compile_options(elements PRIVATE
 
 if (MSVC)
    # Kinda silly to have to do this: https://bit.ly/2ZXjzzn
-   STRING(REGEX REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+   STRING(REGEX REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 if (APPLE)


### PR DESCRIPTION
Without this fix it will complain about the function needing at least 6 arguments.