### PR TITLE
Add coverity scans

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,78 @@
+name: Coverity
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+jobs:
+  build:
+    name: Coverity
+    runs-on: ubuntu-latest
+    environment: Coverity
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install package dependencies
+      id: cmake_and_ninja
+      shell: cmake -P {0}
+      run: |
+        execute_process(COMMAND sudo apt-get update)
+        execute_process(COMMAND sudo apt-get install libcairo2-dev)
+        execute_process(COMMAND sudo apt-get install libgtk-3-dev)
+        execute_process(COMMAND sudo apt-get install ninja-build)
+        execute_process(COMMAND sudo apt-get install wget)
+    - name: Download Coverity Build Tool
+      run: |
+        wget -q https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=cycfi%2Felements" -O cov-analysis-linux64.tar.gz
+        mkdir cov-analysis-linux64
+        tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+      env:
+        TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+    - name: Configure
+      shell: cmake -P {0}
+      run: |
+        set(ENV{CC} gcc-11)
+        set(ENV{CXX} g++-11)
+    
+        execute_process(
+          COMMAND ${CMAKE_COMMAND}
+            -S .
+            -B build
+            -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
+            -G Ninja
+            -D CMAKE_MAKE_PROGRAM=ninja
+          RESULT_VARIABLE result
+          ERROR_VARIABLE error_message
+        )
+
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Could not run with ${CMAKE_COMMAND}: Got ${error_message} - ${result}")
+        endif()
+    - name: Build
+      shell: |
+        export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
+        cmake -P {0}
+      run: |
+        execute_process(
+          COMMAND cov-build --dir cov-int ${CMAKE_COMMAND} --build build
+          RESULT_VARIABLE result
+          ERROR_VARIABLE error_message
+        )
+
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Could not run with ${CMAKE_COMMAND}: Got ${error_message} - ${result}")
+        endif()
+    - name: Submit the result to Coverity Scan
+      run: |
+        tar czvf elements.tgz cov-int
+        curl \
+          --form token=$TOKEN \
+          --form email=$EMAIL \
+          --form file=@elements.tgz \
+          --form version="master" \
+          --form description="master" \
+          https://scan.coverity.com/builds?project=cycfi%2Felements
+      env:
+        TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}


### PR DESCRIPTION
This requires a new environment to be created with the token and email address from coverity. Due to that I was not able to test this. I think you could put this into a separate branch and then then use the manual trigger to test it.