### PR TITLE
Useful code brought over from before the flip to cairo.

### DIFF
--- a/lib/include/elements/support/canvas.hpp
+++ b/lib/include/elements/support/canvas.hpp
@@ -168,6 +168,7 @@ namespace cycfi { namespace elements
          float       ascent;
          float       descent;
          float       height;
+         float       leading;
       };
 
                         [[deprecated("Use fill_text(utf8, p) instead following artist API.")]]

--- a/lib/include/elements/support/canvas.hpp
+++ b/lib/include/elements/support/canvas.hpp
@@ -163,6 +163,13 @@ namespace cycfi { namespace elements
          point       size;
       };
 
+      struct font_metrics
+      {
+         float       ascent;
+         float       descent;
+         float       height;
+      };
+
                         [[deprecated("Use fill_text(utf8, p) instead following artist API.")]]
       void              fill_text(point p, char const* utf8);
       void              fill_text(std::string_view utf8, point p);
@@ -173,6 +180,8 @@ namespace cycfi { namespace elements
 
       text_metrics      measure_text(char const* utf8);
       void              text_align(int align);
+
+      font_metrics      measure_font();
 
       ///////////////////////////////////////////////////////////////////////////////////
       // Pixmaps

--- a/lib/include/elements/support/color.hpp
+++ b/lib/include/elements/support/color.hpp
@@ -100,6 +100,26 @@ namespace cycfi { namespace elements
       return r;
    }
 
+   constexpr color operator+(color const& a, color const& b)
+   {
+      return color(a.red + b.red, a.green + b.green, a.blue + b.blue, a.alpha + b.alpha*(1.0-a.alpha));
+   }
+
+   constexpr color operator-(color const& a, color const& b)
+   {
+      return color(a.red - b.red, a.green - b.green, a.blue - b.blue, a.alpha + b.alpha*(1.0-a.alpha));
+   }
+
+   constexpr color operator*(color const& a, float b)
+   {
+      return color(a.red * b, a.green * b, a.blue * b, a.alpha);
+   }
+
+   constexpr color operator*(float a, color const& b)
+   {
+      return color(a * b.red, a * b.green, a * b.blue, b.alpha);
+   }
+
    ////////////////////////////////////////////////////////////////////////////
    // Common colors
    ////////////////////////////////////////////////////////////////////////////

--- a/lib/include/elements/support/rect.hpp
+++ b/lib/include/elements/support/rect.hpp
@@ -65,6 +65,7 @@ namespace cycfi { namespace elements
    constexpr bool       is_valid(rect r);
    constexpr bool       is_same_size(rect a, rect b);
    bool                 intersects(rect a, rect b);
+   rect                 intersection(rect const& a, rect const& b);
 
    constexpr point      center_point(rect r);
    constexpr float      area(rect r);

--- a/lib/src/support/canvas.cpp
+++ b/lib/src/support/canvas.cpp
@@ -421,7 +421,13 @@ namespace cycfi { namespace elements
    {
      cairo_font_extents_t font_extents;
      cairo_scaled_font_extents(cairo_get_scaled_font(&_context), &font_extents);
-     return font_extents;
+
+      return {
+         /*ascent=*/    float(font_extents.ascent),
+         /*descent=*/   float(font_extents.descent),
+         /*height=*/   float(font_extents.height),
+         /*leading=*/   float(font_extents.height-(font_extents.ascent+font_extents.descent))
+      };
    }
 
    void canvas::draw(pixmap const& pm, elements::rect src, elements::rect dest)

--- a/lib/src/support/canvas.cpp
+++ b/lib/src/support/canvas.cpp
@@ -417,6 +417,13 @@ namespace cycfi { namespace elements
       };
    }
 
+   canvas::font_metrics canvas::measure_font()
+   {
+     cairo_font_extents_t font_extents;
+     cairo_scaled_font_extents(cairo_get_scaled_font(&_context), &font_extents);
+     return font_extents;
+   }
+
    void canvas::draw(pixmap const& pm, elements::rect src, elements::rect dest)
    {
       auto  state = new_state();
@@ -443,4 +450,3 @@ namespace cycfi { namespace elements
       cairo_restore(&_context);
    }
 }}
-

--- a/lib/src/support/rect.cpp
+++ b/lib/src/support/rect.cpp
@@ -18,6 +18,16 @@ namespace cycfi { namespace elements
       return true;
    }
 
+   rect intersection(rect const& a, rect const& b)
+   {
+      return {
+         std::max(a.left, b.left),
+         std::max(a.top, b.top),
+         std::min(a.right, b.right),
+         std::min(a.bottom, b.bottom)
+      };
+   }
+
    rect max(rect a, rect b)
    {
       return {


### PR DESCRIPTION
My code base was on an old version before the change to cairo. I depended on several bits of code in the `cycfi::artist` library that were left out during the flip to cairo. I've reintegrated those and believe that are generally useful for merging back into master. 