### PR TITLE
Add missing vmax_size functionalities

### DIFF
--- a/lib/include/elements/element/size.hpp
+++ b/lib/include/elements/element/size.hpp
@@ -484,6 +484,56 @@ namespace cycfi::elements
    }
 
    ////////////////////////////////////////////////////////////////////////////
+   template <concepts::Element Subject>
+   class vmax_size_element : public proxy<Subject>
+   {
+   public:
+
+      using base_type = proxy<Subject>;
+
+                              vmax_size_element(float size, Subject subject);
+
+      view_limits             limits(basic_context const& ctx) const override;
+      void                    prepare_subject(context& ctx) override;
+
+      void                    vmax_size(float size) { _size = size; }
+      float                   vmax_size() const { return _size; }
+
+   private:
+
+      float                   _size;
+   };
+
+   template <concepts::Element Subject>
+   inline vmax_size_element<Subject>::vmax_size_element(float size, Subject subject)
+    : base_type(std::move(subject))
+    , _size(size)
+   {}
+
+   template <concepts::Element Subject>
+   inline vmax_size_element<remove_cvref_t<Subject>>
+   vmax_size(float size, Subject&& subject)
+   {
+      return {size, std::forward<Subject>(subject)};
+   }
+
+   template <concepts::Element Subject>
+   inline view_limits vmax_size_element<Subject>::limits(basic_context const& ctx) const
+   {
+      auto  e_limits = this->subject().limits(ctx);
+      float size_y = _size;
+      clamp(size_y, e_limits.min.y, e_limits.max.y);
+      return {{e_limits.min.x, e_limits.min.y}, {size_y, e_limits.max.y}};
+   }
+
+   template <concepts::Element Subject>
+   inline void vmax_size_element<Subject>::prepare_subject(context& ctx)
+   {
+      if (ctx.bounds.height() > _size)
+         ctx.bounds.height(_size);
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
    // Stretch elements
    ////////////////////////////////////////////////////////////////////////////
    template <concepts::Element Subject>


### PR DESCRIPTION
Simple code additions to **size.hpp** to add missing _vmax_size_ functions to mirror the existing _hmax_size_ functions.

Changes tested using the following simple skeleton code. Notice that the blue box in the side panel will have its height constrained to 400.0f.
```
#include "elements/support/color.hpp"
#include <elements.hpp>


using namespace cycfi::elements;

constexpr float initial_client_width = 1024.f;
constexpr float initial_client_height = 768.f;


auto make_sidebar_column(view& view_) {
    auto sidebar_column =
        hmax_size(
            265.0f,
            vtile(
                vmax_size(
                    400.0f,
                    box(colors::blue)
                ),
                box(colors::yellow)
            )
    );
    return sidebar_column;
}


auto make_inbox_column(view& view_) {
    auto inbox_column =
        vtile(
            box(colors::red)
        );
    return inbox_column;
}


auto make_details_column(view& view_) {
    auto details_column =
        hmax_size(
            400.0f,
            vtile(
                box(colors::green)
            )
    );
    return details_column;
}


auto make_layout(view& view_) {
    auto layout =
        htile( 
            make_sidebar_column(view_), 
            make_inbox_column(view_), 
            make_details_column(view_)
        );
    return layout;
}


int run_application() {
    app _app("learn");
    window _win(_app.name(), window::style::standard);
    _win.on_close = [&_app]() { _app.stop(); };

    view view_(_win);

    view_.content(
        min_size(
            {initial_client_width, initial_client_height}, 
            make_layout(view_)
        )
    );

    _app.run();
    return 0;
}


#if defined(_WIN32) // win32 and win64
    int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hInstPrev, PSTR cmdline, int cmdshow) {
        return run_application();
    }
#else
    int main(int argc, char* argv[]) {
        return run_application();
    }
#endif
```

I am learning Elements and testing the library by attempting to replicate this layout as seen on [https://ui.shadcn.com/](https://ui.shadcn.com/)
![Screenshot_20240911_150958-transformed](https://github.com/user-attachments/assets/7ccc6240-423c-4d5a-8be9-6f9b16957d0d)
