### PR TITLE
Fixed a non-resizable window issue[#428]

### DIFF
--- a/lib/host/windows/window.cpp
+++ b/lib/host/windows/window.cpp
@@ -43,20 +43,23 @@ namespace cycfi::elements
       void disable_minimize(HWND hwnd)
       {
          SetWindowLongW(hwnd, GWL_STYLE,
-         GetWindowLongW(hwnd, GWL_STYLE) & ~WS_MINIMIZEBOX);
+            GetWindowLongW(hwnd, GWL_STYLE) & ~WS_MINIMIZEBOX);
+         SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
       }
 
+      [[maybe_unused]]
       void disable_maximize(HWND hwnd)
       {
          SetWindowLongW(hwnd, GWL_STYLE,
-         GetWindowLongW(hwnd, GWL_STYLE) & ~WS_MAXIMIZEBOX);
+            GetWindowLongW(hwnd, GWL_STYLE) & ~WS_MAXIMIZEBOX);
+         SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
       }
 
       void disable_resize(HWND hwnd)
       {
          SetWindowLongW(hwnd, GWL_STYLE,
-            GetWindowLongW(hwnd, GWL_STYLE) & ~WS_SIZEBOX);
-         disable_maximize(hwnd);
+            GetWindowLongW(hwnd, GWL_STYLE) & ~WS_SIZEBOX & ~WS_MAXIMIZEBOX);
+         SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
       }
 
       LRESULT on_close(window* win)


### PR DESCRIPTION
Non-resizable window appears with white borders when they are created and moved. I found that the reason is that the code does not notify the system when the border style of the window's frame is changed.

issue https://github.com/cycfi/elements/issues/428