### PR TITLE
adjust the position of the input method window so that it follows the caret

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -348,9 +348,10 @@ if (WIN32 AND NOT MSVC)
    target_link_libraries(elements PUBLIC ws2_32)
 endif()
 
-# Replace missing Shcore library removed by WIN32_LEAN_AND_MEAN
+# 1.Replace missing Shcore library removed by WIN32_LEAN_AND_MEAN
+# 2.IME requires Imm32
 if (WIN32)
-   target_link_libraries(elements PUBLIC Shcore)
+   target_link_libraries(elements PUBLIC Shcore Imm32)
 endif()
 
 add_library(cycfi::elements ALIAS elements)

--- a/lib/host/windows/key.cpp
+++ b/lib/host/windows/key.cpp
@@ -72,7 +72,7 @@ namespace cycfi::elements
       {
          // IME notifies that keys have been filtered by setting the virtual
          // key-code to VK_PROCESSKEY
-         return key_code::unknown;
+         return key_code::ime_process_key;
       }
 
       unsigned int key = HIWORD(lparam) & 0x1FF;
@@ -206,5 +206,6 @@ namespace cycfi::elements
          case 0x037:  return key_code::kp_multiply;
          case 0x04a:  return key_code::kp_subtract;
       }
+      return key_code::unknown;
    }
 }

--- a/lib/include/elements/base_view.hpp
+++ b/lib/include/elements/base_view.hpp
@@ -144,6 +144,9 @@ namespace cycfi::elements
 
    enum class key_code : int16_t
    {
+#ifdef WIN32
+      ime_process_key   = -2,
+#endif
       unknown           = -1,
 
       // Printable keys

--- a/lib/include/elements/element/text.hpp
+++ b/lib/include/elements/element/text.hpp
@@ -156,6 +156,7 @@ namespace cycfi::elements
 
       char const*             caret_position(context const& ctx, point p);
       glyph_metrics           glyph_info(context const& ctx, char const* s);
+      bool                    get_caret_position(context const& ctx, rect& caret_bounds);
 
    private:
 


### PR DESCRIPTION
before
![图片](https://github.com/user-attachments/assets/4ce6f190-f492-42c9-9d76-8a6b99235e14)

after
![图片](https://github.com/user-attachments/assets/d80226cd-fbdc-45fe-a2c3-b5febc81128c)
