### PR TITLE
Add missing make_pixmap function

### DIFF
--- a/lib/include/elements/support/pixmap.hpp
+++ b/lib/include/elements/support/pixmap.hpp
@@ -25,6 +25,11 @@ namespace cycfi { namespace elements
       using std::runtime_error::runtime_error;
    };
 
+   enum class pixel_format {
+      invalid = -1,
+      rgba32,
+   };
+
    class pixmap
    {
    public:
@@ -46,6 +51,13 @@ namespace cycfi { namespace elements
 
       friend class canvas;
       friend class pixmap_context;
+
+      template <pixel_format fmt>
+      friend typename std::enable_if<fmt == pixel_format::rgba32, pixmap>::type
+      make_pixmap(std::uint8_t const *data, extent size, float scale);
+
+      explicit pixmap(std::uint8_t const *data, pixel_format fmt, extent size,
+                      float scale);
 
       cairo_surface_t*  _surface;
    };
@@ -101,6 +113,18 @@ namespace cycfi { namespace elements
       }
       return *this;
    }
-}}
+
+   //--------------------------------------------------------------------------
+   // Inlines
+   //--------------------------------------------------------------------------
+
+   template <pixel_format fmt>
+   inline typename std::enable_if<fmt == pixel_format::rgba32, pixmap>::type
+   make_pixmap(std::uint8_t const *data, extent size, float scale=1)
+   {
+      return pixmap(reinterpret_cast<std::uint8_t const *>(data), fmt, size, scale);
+   }
+
+   }}
 
 #endif


### PR DESCRIPTION
I had a looked at the skia_2024 branch and tried to create an interface to be able to update an image from a data structure.

I don't know if it's a good idea to have rgba32 (uint32_t) as a pixel format.  This makes the user of the library tackle the endian issue as shown in the example below.  If we instead have a pixel format rgba as an uint8_t[4] this will no longer be an issue.

Note that in this PR 'make_pixmap' for rgba32 takes a pointer to uint8_t, not uint32_t.  This makes the point of having these template friend functions less relevant.  

Not sure how strict you want to follow the skia_branch so some guidance would be appreciated. 

```cpp
#include <elements.hpp>
#include <bit>
#include <vector>

using namespace cycfi::elements;

auto create_rgba32_pixmap()
{
   const int w = 600;
   const int h = 600;
   std::vector<std::uint8_t> buf(w * h * 4);

   for (int y = 0; y != h; ++y) {
      uint8_t *dest = buf.data() + (y * w * 4);
      for (int x = 0; x != w; ++x) {
         float nx = (float)x / w;
         float ny = (float)y / h;
         std::uint8_t r = static_cast<std::uint8_t>(255 * nx);
         std::uint8_t g = static_cast<std::uint8_t>(255 * ny);
         std::uint8_t b = static_cast<std::uint8_t>(255 * (1 - nx) * (1 - ny));
         std::uint8_t a = 255;

         // RGBA32
         if constexpr (std::endian::native == std::endian::big)
         {
            dest[0] = r;
            dest[1] = g;
            dest[2] = b;
            dest[3] = a;
         } else if constexpr (std::endian::native == std::endian::little)
         {
            dest[0] = a;
            dest[1] = b;
            dest[2] = g;
            dest[3] = r;
         }
         dest += 4;
      }
   }

   return make_pixmap<pixel_format::rgba32>(buf.data(), {w, h});
}

int main(int argc, char *argv[]) {
   app _app("Hello pixmap");
   window _win(_app.name());
   _win.on_close = [&_app]() { _app.stop(); };

   view view_(_win);

   auto pm = std::make_shared<pixmap>(create_rgba32_pixmap());
   view_.content(scroller(image{pm}));

   _app.run();
   return 0;
}
```
