### PR TITLE
fix: Remove duplicate source file entries in CMakeLists.txt

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,12 +57,8 @@ set(ELEMENTS_SOURCES
    src/support/rect.cpp
    src/support/text_utils.cpp
    src/support/resource_paths.cpp
-   src/support/text_utils.cpp
    src/support/theme.cpp
    src/support/payload.cpp
-   src/support/receiver.cpp
-   src/support/text_utils.cpp
-   src/support/theme.cpp
    src/view.cpp
 )
 


### PR DESCRIPTION
- Removed duplicate entries for src/support/text_utils.cpp (appeared 3 times)
- Removed duplicate entry for src/support/receiver.cpp (appeared 2 times)
- Removed duplicate entry for src/support/theme.cpp (appeared 2 times)

This improves build efficiency and prevents potential linking issues. Build verified to work correctly after changes.