### PR TITLE
Selection keys fix - calling on_select for keys selection events

### DIFF
--- a/lib/src/element/selection.cpp
+++ b/lib/src/element/selection.cpp
@@ -296,11 +296,17 @@ namespace cycfi::elements
             case key_code::a:
                if (k.modifiers & mod_action)
                {
-                  if (auto c = find_subject<composite_base*>(this))
+                  if (_multi_select)
                   {
-                     detail::select_all(*c);
-                     ctx.view.refresh(ctx);
-                     return true;
+                     if (auto c = find_subject<composite_base*>(this))
+                     {
+                        detail::select_all(*c);
+                        _select_start = 0;
+                        _select_end = c->size()-1;
+                        on_select(_select_start, _select_end);
+                        ctx.view.refresh(ctx);
+                        return true;
+                     }
                   }
                }
                break;
@@ -324,6 +330,7 @@ namespace cycfi::elements
                         [&](context const& cctx)
                         {
                            scrollable::find(ctx).scroll_into_view(c->bounds_of(cctx, _select_end));
+                           on_select(_select_start, _select_end);
                            ctx.view.refresh(ctx);
                         }
                      );
@@ -352,6 +359,7 @@ namespace cycfi::elements
                         [&](context const& cctx)
                         {
                            scrollable::find(ctx).scroll_into_view(c->bounds_of(cctx, _select_end));
+                           on_select(_select_start, _select_end);
                            ctx.view.refresh(ctx);
                         }
                      );


### PR DESCRIPTION
Proposed solution to #443

I noticed the Ctrl+a (select all) shortcut was also not calling on_select so have proposed a solution there too - which copies the selection_list_element::select_all() method. With a check included for if the selection_list_element has multi_select enabled. I am assuming the desired Ctrl+a behaviour with multi-select disabled is do nothing.



