### PR TITLE
Update Asio to 1.36.0 and refactor io_context usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ xcuserdata/
 /CMakeSettings.json
 /docs/antora/node_modules/
 /docs/antora/build/
+/.cache/

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -271,7 +271,7 @@ endif()
 FetchContent_Declare(
   asio
   GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
-  GIT_TAG asio-1-29-0
+  GIT_TAG asio-1-36-0
   GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(asio)

--- a/lib/include/elements/view.hpp
+++ b/lib/include/elements/view.hpp
@@ -145,7 +145,7 @@ namespace cycfi::elements
       undo_stack_type         _redo_stack;
 
       io_context              _io;
-      io_context::work        _work;
+      asio::executor_work_guard<io_context::executor_type>        _work;
 
       using time_point = std::chrono::steady_clock::time_point;
       using tracking_map = std::map<element*, time_point>;
@@ -241,7 +241,7 @@ namespace cycfi::elements
          if (std::find(_content.begin(), _content.end(), e) != _content.end())
             return;
 
-         io().post(
+         asio::post(io(),
             [e, this, focus_top]
             {
                auto wants_focus = focus_top && e->wants_focus();
@@ -279,7 +279,7 @@ namespace cycfi::elements
       // post a function that is called at idle time.
       if (e)
       {
-         io().post(
+         asio::post(io(),
             [e, this]
             {
                auto i = std::find(_content.begin(), _content.end(), e);
@@ -316,7 +316,7 @@ namespace cycfi::elements
    {
       if (e && _content.back() != e)
       {
-         io().post(
+         asio::post(io(),
             [e, this]
             {
                auto i = std::find(_content.begin(), _content.end(), e);
@@ -337,7 +337,7 @@ namespace cycfi::elements
    {
       if (e && _content.front() != e)
       {
-         io().post(
+         asio::post(io(),
             [e, this]
             {
                auto i = std::find(_content.begin(), _content.end(), e);
@@ -393,7 +393,7 @@ namespace cycfi::elements
    template <typename F>
    inline void view::post(F f)
    {
-      _io.post(f);
+      asio::post(_io, f);
    }
 }
 

--- a/lib/src/view.cpp
+++ b/lib/src/view.cpp
@@ -12,19 +12,19 @@
    view::view(extent size_)
     : base_view(size_)
     , _main_element(make_scaled_content())
-    , _work(_io)
+    , _work(asio::make_work_guard(_io))
    {}
 
    view::view(host_view_handle h)
     : base_view(h)
     , _main_element(make_scaled_content())
-    , _work(_io)
+    , _work(asio::make_work_guard(_io))
    {}
 
    view::view(window& win)
     : base_view(win.host())
     , _main_element(make_scaled_content())
-    , _work(_io)
+    , _work(asio::make_work_guard(_io))
    {
       on_change_limits = [&win](view_limits limits_)
       {
@@ -142,7 +142,7 @@
    void view::refresh()
    {
       // Allow refresh to be called from another thread
-      _io.post(
+      asio::post(_io,
          [this]()
          {
             base_view::refresh();
@@ -153,7 +153,7 @@
    void view::refresh(rect area)
    {
       // Allow refresh to be called from another thread
-      _io.post(
+      asio::post(_io,
          [this, area]()
          {
             base_view::refresh(area);
@@ -173,7 +173,7 @@
       if (_current_bounds.is_empty())
          return;
 
-      _io.post(
+      asio::post(_io,
          [this, &element, outward]()
          {
             with_context_do(


### PR DESCRIPTION
Fixes https://github.com/cycfi/elements/issues/445
Bump Asio dependency from 1.29.0 to 1.36.0 in CMake configuration. 
Refactor usage of io_context::work to asio::executor_work_guard and replace io().post with asio::post for improved compatibility with newer Asio versions. 