### PR TITLE
ci(coverity): surface download errors instead of bare exit code

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,7 +25,16 @@ jobs:
         execute_process(COMMAND sudo apt-get install wget)
     - name: Download Coverity Build Tool
       run: |
-        wget -q https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=cycfi%2Felements" -O cov-analysis-linux64.tar.gz
+        # -S prints the server's HTTP response headers so failures (bad token,
+        # quota exceeded, server error) are visible instead of a bare exit code.
+        wget -S https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=cycfi%2Felements" -O cov-analysis-linux64.tar.gz
+        # Coverity returns an HTML/text error page (HTTP 200) on a bad token, so
+        # verify we actually got a gzip archive before trying to unpack it.
+        if ! file cov-analysis-linux64.tar.gz | grep -q gzip; then
+          echo "::error::Coverity did not return a gzip archive. Server response:"
+          cat cov-analysis-linux64.tar.gz
+          exit 1
+        fi
         mkdir cov-analysis-linux64
         tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
       env:


### PR DESCRIPTION
## Problem

The scheduled **Coverity** scan has been failing at the **Download Coverity Build Tool** step with only `Process completed with exit code 8` ([example run](https://github.com/cycfi/elements/actions/runs/27125658634)).

Exit code 8 from `wget` means *"Server issued an error response"* — `scan.coverity.com` returned an error instead of the build-tool tarball. The step used `wget -q`, so the actual cause (bad/expired token, quota exceeded, or a server-side error) was hidden.

## Change

- Use `wget -S` to print the HTTP response headers in the log.
- Validate that the download is actually a gzip archive before unpacking. Coverity serves a plain error page (sometimes with HTTP 200) when the token is wrong, so this catches that case and dumps the server response to the log.

This does **not** fix the underlying download failure — it makes the next run report *why* it failed. The most likely root cause is an invalid/expired `COVERITY_SCAN_TOKEN` secret or a Coverity Scan quota/server issue. Trigger via **Run workflow** (workflow_dispatch) after merge to see the real error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)